### PR TITLE
usersip: allow the username to be specified

### DIFF
--- a/xivo_dao/alchemy/tests/test_usersip.py
+++ b/xivo_dao/alchemy/tests/test_usersip.py
@@ -4,7 +4,7 @@
 
 from hamcrest import (
     assert_that,
-    equal_to,
+    has_properties,
 )
 
 from xivo_dao.tests.test_dao import DAOTestCase
@@ -12,9 +12,20 @@ from xivo_dao.tests.test_dao import DAOTestCase
 
 class TestUserSIP(DAOTestCase):
 
-    def test_setting_a_username_when_options_is_in_the_body(self):
-        params = {'username': 'foobar', 'name': 'foo', 'options': []}
+    def test_exclude_options_confd_ignore_options_key(self):
+        exclude_options_confd = {
+            'name': 'foo',
+            'username': 'foobar',
+            'secret': 's3cret',
+            'type': 'peer',
+            'host': 'my-host',
+            'context': 'my-context',
+            'category': 'user',
+            'protocol': 'sip',
+        }
 
-        sip = self.add_usersip(**params)
+        body = dict(exclude_options_confd)
+        body['options'] = []
+        sip = self.add_usersip(**body)
 
-        assert_that(sip.username, equal_to('foobar'))
+        assert_that(sip, has_properties(exclude_options_confd))

--- a/xivo_dao/alchemy/tests/test_usersip.py
+++ b/xivo_dao/alchemy/tests/test_usersip.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+)
+
+from xivo_dao.tests.test_dao import DAOTestCase
+
+
+class TestUserSIP(DAOTestCase):
+
+    def test_setting_a_username_when_options_is_in_the_body(self):
+        params = {'username': 'foobar', 'name': 'foo', 'options': []}
+
+        sip = self.add_usersip(**params)
+
+        assert_that(sip.username, equal_to('foobar'))

--- a/xivo_dao/alchemy/usersip.py
+++ b/xivo_dao/alchemy/usersip.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -31,6 +31,7 @@ class UserSIP(Base, AsteriskOptionsMixin):
     }
     EXCLUDE_OPTIONS_CONFD = {
         'name',
+        'username',
         'secret',
         'type',
         'host',

--- a/xivo_dao/resources/endpoint_sip/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_sip/tests/test_dao.py
@@ -360,31 +360,6 @@ class TestCreate(DAOTestCase):
             category='user',
         ))
 
-    def test_create_with_different_name_same_username(self):
-        username = 'my-foobar-account'
-
-        foo_model = SIPEndpoint(
-            tenant_uuid=self.default_tenant.uuid,
-            name='foo',
-            username=username,
-            secret='mysecret',
-            host="127.0.0.1",
-            type="peer",
-        )
-        foo = sip_dao.create(foo_model)
-
-        bar_model = SIPEndpoint(
-            tenant_uuid=self.default_tenant.uuid,
-            name='bar',
-            username=username,
-            secret='mysecret',
-            host="127.0.0.1",
-            type="peer",
-        )
-        bar = sip_dao.create(bar_model)
-
-        assert_that(foo.username, equal_to(bar.username))
-
     def test_create_with_native_options(self):
         sip_model = SIPEndpoint(tenant_uuid=self.default_tenant.uuid, options=ALL_OPTIONS)
 

--- a/xivo_dao/resources/endpoint_sip/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_sip/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -359,6 +359,31 @@ class TestCreate(DAOTestCase):
             host='127.0.0.1',
             category='user',
         ))
+
+    def test_create_with_different_name_same_username(self):
+        username = 'my-foobar-account'
+
+        foo_model = SIPEndpoint(
+            tenant_uuid=self.default_tenant.uuid,
+            name='foo',
+            username=username,
+            secret='mysecret',
+            host="127.0.0.1",
+            type="peer",
+        )
+        foo = sip_dao.create(foo_model)
+
+        bar_model = SIPEndpoint(
+            tenant_uuid=self.default_tenant.uuid,
+            name='bar',
+            username=username,
+            secret='mysecret',
+            host="127.0.0.1",
+            type="peer",
+        )
+        bar = sip_dao.create(bar_model)
+
+        assert_that(foo.username, equal_to(bar.username))
 
     def test_create_with_native_options(self):
         sip_model = SIPEndpoint(tenant_uuid=self.default_tenant.uuid, options=ALL_OPTIONS)


### PR DESCRIPTION
Add the username to the EXCLUDE_OPTIONS_CONFD list. Without adding adding the
options to the payload result in the username being reset to None by the
AsteriskOptionsMixin.