### PR TITLE
endpoint_sip: set the username to match the name

### DIFF
--- a/xivo_dao/resources/endpoint_sip/persistor.py
+++ b/xivo_dao/resources/endpoint_sip/persistor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import partial
@@ -92,6 +92,13 @@ class SipPersistor(CriteriaBuilderMixin):
     def fill_default_values(self, sip):
         if sip.name is None:
             sip.name = generators.find_unused_hash(partial(self._already_exists, SIP.name))
+
+        # This is a compatibility fix that was added in 19.15 to avoid breaking the API.
+        # In the old version, the name could not be specified in the API the username was
+        # always copied.
+        if sip.username is None:
+            sip.username = sip.name
+
         if sip.secret is None:
             sip.secret = generators.find_unused_hash(partial(self._already_exists, SIP.secret))
         if sip.type is None:

--- a/xivo_dao/resources/endpoint_sip/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_sip/tests/test_dao.py
@@ -329,7 +329,7 @@ class TestCreate(DAOTestCase):
         assert_that(sip, has_properties(
             id=not_none(),
             name=has_length(8),
-            username=none(),
+            username=sip.name,
             secret=has_length(8),
             type='friend',
             host='dynamic',
@@ -353,7 +353,7 @@ class TestCreate(DAOTestCase):
             id=not_none(),
             tenant_uuid=self.default_tenant.uuid,
             name='myusername',
-            username=none(),
+            username='myusername',
             secret='mysecret',
             type='peer',
             host='127.0.0.1',


### PR DESCRIPTION
the API used to set the username field input into the name column and did not
allow the user to specify a username.

this change allow the new API to allow the user to create an endpoint with a
name and a username while keeping the same behavior for users using the API the
"old" way.