### PR TITLE
Pull request for WAZO-580-search-by-user-uuid

### DIFF
--- a/xivo_dao/resources/access_feature/tests/test_dao.py
+++ b/xivo_dao/resources/access_feature/tests/test_dao.py
@@ -5,16 +5,13 @@
 from __future__ import unicode_literals
 
 from hamcrest import (
-    all_of,
     assert_that,
     contains,
-    empty,
     equal_to,
     has_items,
     has_properties,
     has_property,
     none,
-    not_,
     not_none,
 )
 
@@ -184,14 +181,14 @@ class TestSearchGivenMultipleAccessFeatures(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_name_of_items(self):
+    def test_when_offset_then_returns_right_name_of_items(self):
         expected = SearchResult(4, [
             self.access_feature2,
             self.access_feature3,
             self.access_feature4
         ])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.access_feature2])
@@ -201,7 +198,7 @@ class TestSearchGivenMultipleAccessFeatures(TestSearch):
             search='24',
             order='host',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/agent/tests/test_dao.py
+++ b/xivo_dao/resources/agent/tests/test_dao.py
@@ -298,10 +298,10 @@ class TestSearchGivenMultipleAgent(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.agent2, self.agent3, self.agent4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.agent2])
@@ -310,7 +310,7 @@ class TestSearchGivenMultipleAgent(TestSearch):
                                           search='a',
                                           order='firstname',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/call_filter/tests/test_dao.py
+++ b/xivo_dao/resources/call_filter/tests/test_dao.py
@@ -286,10 +286,10 @@ class TestSearchGivenMultipleCallFilters(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.call_filter2, self.call_filter3, self.call_filter4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.call_filter2])
@@ -299,7 +299,7 @@ class TestSearchGivenMultipleCallFilters(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/call_permission/tests/test_dao.py
+++ b/xivo_dao/resources/call_permission/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -281,10 +281,10 @@ class TestSearchGivenMultipleCallPermissions(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.call_permission2, self.call_permission3, self.call_permission4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.call_permission2])
@@ -294,7 +294,7 @@ class TestSearchGivenMultipleCallPermissions(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/call_pickup/tests/test_dao.py
+++ b/xivo_dao/resources/call_pickup/tests/test_dao.py
@@ -303,10 +303,10 @@ class TestSearchGivenMultipleCallPickups(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.call_pickup2, self.call_pickup3, self.call_pickup4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.call_pickup2])
@@ -316,7 +316,7 @@ class TestSearchGivenMultipleCallPickups(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/conference/tests/test_dao.py
+++ b/xivo_dao/resources/conference/tests/test_dao.py
@@ -284,10 +284,10 @@ class TestSearchGivenMultipleConferences(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.conference2, self.conference3, self.conference4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.conference2])
@@ -296,7 +296,7 @@ class TestSearchGivenMultipleConferences(TestSearch):
                                           search='a',
                                           order='name',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/context/tests/test_dao.py
+++ b/xivo_dao/resources/context/tests/test_dao.py
@@ -243,10 +243,10 @@ class TestSearchGivenMultipleContext(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.context2, self.context3, self.context4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.context2])
@@ -255,7 +255,7 @@ class TestSearchGivenMultipleContext(TestSearch):
                                           search='a',
                                           order='type',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/endpoint_sip/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_sip/tests/test_dao.py
@@ -299,10 +299,10 @@ class TestSearchMultiple(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.sip2, self.sip3, self.sip4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.sip2])
@@ -312,7 +312,7 @@ class TestSearchMultiple(TestSearch):
             search='a',
             order='username',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/extension/tests/test_dao.py
+++ b/xivo_dao/resources/extension/tests/test_dao.py
@@ -138,10 +138,10 @@ class TestSearchGivenMultipleExtensions(TestExtension):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(5, [self.extension2, self.extension3, self.extension4, self.extension5])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.extension2])
@@ -150,7 +150,7 @@ class TestSearchGivenMultipleExtensions(TestExtension):
                                           search='100',
                                           order='exten',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/group/tests/test_dao.py
+++ b/xivo_dao/resources/group/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -275,10 +275,10 @@ class TestSearchGivenMultipleGroup(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.group2, self.group3, self.group4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.group2])
@@ -287,7 +287,7 @@ class TestSearchGivenMultipleGroup(TestSearch):
                                           search='a',
                                           order='name',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/incall/tests/test_dao.py
+++ b/xivo_dao/resources/incall/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -290,10 +290,10 @@ class TestSearchGivenMultipleIncall(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.incall2, self.incall3, self.incall4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.incall2])
@@ -302,7 +302,7 @@ class TestSearchGivenMultipleIncall(TestSearch):
                                           search='a',
                                           order='preprocess_subroutine',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/ivr/tests/test_dao.py
+++ b/xivo_dao/resources/ivr/tests/test_dao.py
@@ -274,10 +274,10 @@ class TestSearchGivenMultipleIncall(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.ivr2, self.ivr3, self.ivr4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.ivr3])
@@ -287,7 +287,7 @@ class TestSearchGivenMultipleIncall(TestSearch):
             search='resto',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/moh/tests/test_dao.py
+++ b/xivo_dao/resources/moh/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -267,10 +267,10 @@ class TestSearchGivenMultipleMOH(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.moh2, self.moh3, self.moh4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.moh3])
@@ -280,7 +280,7 @@ class TestSearchGivenMultipleMOH(TestSearch):
             search='resto',
             order='label',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/outcall/tests/test_dao.py
+++ b/xivo_dao/resources/outcall/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -286,10 +286,10 @@ class TestSearchGivenMultipleOutcall(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.outcall2, self.outcall3, self.outcall4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.outcall2])
@@ -299,7 +299,7 @@ class TestSearchGivenMultipleOutcall(TestSearch):
             search='a',
             order='preprocess_subroutine',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/paging/tests/test_dao.py
+++ b/xivo_dao/resources/paging/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -272,10 +272,10 @@ class TestSearchGivenMultiplePagings(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_name_of_items(self):
+    def test_when_offset_then_returns_right_name_of_items(self):
         expected = SearchResult(4, [self.paging2, self.paging3, self.paging4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.paging2])
@@ -285,7 +285,7 @@ class TestSearchGivenMultiplePagings(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/parking_lot/tests/test_dao.py
+++ b/xivo_dao/resources/parking_lot/tests/test_dao.py
@@ -265,10 +265,10 @@ class TestSearchGivenMultipleParkingLots(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.parking_lot2, self.parking_lot3, self.parking_lot4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.parking_lot2])
@@ -278,7 +278,7 @@ class TestSearchGivenMultipleParkingLots(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/queue/tests/test_dao.py
+++ b/xivo_dao/resources/queue/tests/test_dao.py
@@ -272,10 +272,10 @@ class TestSearchGivenMultipleQueue(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.queue2, self.queue3, self.queue4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.queue2])
@@ -284,7 +284,7 @@ class TestSearchGivenMultipleQueue(TestSearch):
                                           search='a',
                                           order='name',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/register_iax/tests/test_dao.py
+++ b/xivo_dao/resources/register_iax/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -106,10 +106,10 @@ class TestSearchGivenMultipleRegisterIAX(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.register_iax2, self.register_iax3, self.register_iax4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(4, [self.register_iax3])
@@ -117,7 +117,7 @@ class TestSearchGivenMultipleRegisterIAX(TestSearch):
         self.assert_search_returns_result(expected,
                                           order='id',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/register_sip/tests/test_dao.py
+++ b/xivo_dao/resources/register_sip/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -106,10 +106,10 @@ class TestSearchGivenMultipleRegisterSIP(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.register_sip2, self.register_sip3, self.register_sip4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(4, [self.register_sip3])
@@ -117,7 +117,7 @@ class TestSearchGivenMultipleRegisterSIP(TestSearch):
         self.assert_search_returns_result(expected,
                                           order='id',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/schedule/tests/test_dao.py
+++ b/xivo_dao/resources/schedule/tests/test_dao.py
@@ -263,10 +263,10 @@ class TestSearchGivenMultipleSchedules(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_name_of_items(self):
+    def test_when_offset_then_returns_right_name_of_items(self):
         expected = SearchResult(4, [self.schedule2, self.schedule3, self.schedule4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.schedule2])
@@ -276,7 +276,7 @@ class TestSearchGivenMultipleSchedules(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/skill/tests/test_dao.py
+++ b/xivo_dao/resources/skill/tests/test_dao.py
@@ -255,14 +255,14 @@ class TestSearchGivenMultipleSkills(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_name_of_items(self):
+    def test_when_offset_then_returns_right_name_of_items(self):
         expected = SearchResult(4, [
             self.skill2,
             self.skill3,
             self.skill4
         ])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.skill2])
@@ -272,7 +272,7 @@ class TestSearchGivenMultipleSkills(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/skill_rule/tests/test_dao.py
+++ b/xivo_dao/resources/skill_rule/tests/test_dao.py
@@ -80,6 +80,7 @@ class TestGet(DAOTestCase):
             tenant_uuids=[tenant.uuid]
         )
 
+
 class TestFindBy(DAOTestCase):
 
     def test_given_column_does_not_exist_then_error_raised(self):
@@ -231,14 +232,14 @@ class TestSearchGivenMultipleSkillRules(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_name_of_items(self):
+    def test_when_offset_then_returns_right_name_of_items(self):
         expected = SearchResult(4, [
             self.skill_rule2,
             self.skill_rule3,
             self.skill_rule4
         ])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.skill_rule2])
@@ -248,7 +249,7 @@ class TestSearchGivenMultipleSkillRules(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/switchboard/tests/tests_dao.py
+++ b/xivo_dao/resources/switchboard/tests/tests_dao.py
@@ -101,10 +101,10 @@ class TestSearchGivenMultipleSwitchboards(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_name_of_items(self):
+    def test_when_offset_then_returns_right_name_of_items(self):
         expected = SearchResult(4, [self.switchboard2, self.switchboard3, self.switchboard4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.switchboard2])
@@ -114,7 +114,7 @@ class TestSearchGivenMultipleSwitchboards(TestSearch):
             search='a',
             order='name',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/trunk/tests/test_dao.py
+++ b/xivo_dao/resources/trunk/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -265,10 +265,10 @@ class TestSearchGivenMultipleTrunks(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.trunk2, self.trunk3, self.trunk4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.trunk2])
@@ -278,7 +278,7 @@ class TestSearchGivenMultipleTrunks(TestSearch):
             search='a',
             order='context',
             direction='desc',
-            skip=1,
+            offset=1,
             limit=1,
         )
 

--- a/xivo_dao/resources/user/dao.py
+++ b/xivo_dao/resources/user/dao.py
@@ -1,15 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
 
-from sqlalchemy import and_
-
 from xivo_dao.helpers.db_manager import Session
-
-from xivo_dao.resources.utils.search import SearchResult
-from xivo_dao.alchemy.userfeatures import UserFeatures as User
 
 from xivo_dao.resources.user.persistor import UserPersistor
 from xivo_dao.resources.func_key.persistor import DestinationPersistor
@@ -21,16 +16,6 @@ from xivo_dao.resources.user.fixes import UserFixes
 
 def persistor(tenant_uuids=None):
     return UserPersistor(Session, user_view, user_search, tenant_uuids)
-
-
-def legacy_search(term, tenant_uuids):
-    users = (Session.query(User)
-             .filter(and_(User.fullname.ilike('%{}%'.format(term)),
-                          User.tenant_uuid.in_(tenant_uuids)))
-             .all()
-             )
-
-    return SearchResult(len(users), users)
 
 
 def search(**parameters):

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -476,10 +476,10 @@ class TestSearchGivenMultipleUsers(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.user4, self.user3, self.user1])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.user2])
@@ -488,7 +488,7 @@ class TestSearchGivenMultipleUsers(TestSearch):
                                           search='a',
                                           order='firstname',
                                           direction='desc',
-                                          skip=1,
+                                          offset=1,
                                           limit=1)
 
 

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -491,6 +491,16 @@ class TestSearchGivenMultipleUsers(TestSearch):
                                           offset=1,
                                           limit=1)
 
+    def test_when_multiple_uuid_then_returns_right_number_of_items(self):
+        expected = SearchResult(2, [self.user2, self.user3])
+
+        multiple_uuid = ','.join([self.user2.uuid, self.user3.uuid])
+        self.assert_search_returns_result(expected, uuid=multiple_uuid)
+
+    def test_when_uuid_is_none_then_returns_right_number_of_items(self):
+        expected = SearchResult(0, [])
+        self.assert_search_returns_result(expected, uuid=None)
+
 
 class TestCreate(TestUser):
 

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -309,22 +309,6 @@ class TestFindAllBy(TestUser):
                                      has_property('id', user2.id)))
 
 
-class TestLegacySearch(TestUser):
-
-    def test_given_users_when_using_legacy_search_then_searches_on_fullname(self):
-        user1 = self.add_user(firstname="Rîchard", lastname="Làtulippe", tenant_uuid=self.tenant.uuid)
-        user2 = self.add_user(firstname="Jôhn", lastname="Smïth", tenant_uuid=self.tenant.uuid)
-
-        total, users = user_dao.legacy_search("rîch", tenant_uuids=[self.tenant.uuid])
-        assert_that(total, equal_to(1))
-        assert_that(users, contains(has_property('id', user1.id)))
-        assert_that(users, is_not(contains(has_property('id', user2.id))))
-
-        total, users = user_dao.legacy_search("rîch", tenant_uuids=[UNKNOWN_TENANT])
-        assert_that(total, equal_to(0))
-        assert_that(users, empty())
-
-
 class TestSearch(TestUser):
 
     def assert_search_returns_result(self, search_result, **parameters):

--- a/xivo_dao/resources/utils/search.py
+++ b/xivo_dao/resources/utils/search.py
@@ -104,7 +104,7 @@ class SearchSystem(object):
     def _populate_parameters(self, parameters=None):
         new_params = dict(self.DEFAULTS)
         if parameters:
-            parameters['offset'] = parameters.pop('skip', parameters.get('offset', self.DEFAULTS['offset']))
+            parameters.setdefault('offset', self.DEFAULTS['offset'])
             new_params.update(parameters)
 
         return new_params

--- a/xivo_dao/resources/utils/tests/test_search.py
+++ b/xivo_dao/resources/utils/tests/test_search.py
@@ -148,15 +148,6 @@ class TestSearchSystem(DAOTestCase):
         assert_that(total, equal_to(2))
         assert_that(rows, contains(first_user_row, last_user_row))
 
-    def test_given_skip_then_offset_a_number_of_rows(self):
-        self.add_user(lastname='Abigale')
-        last_user_row = self.add_user(lastname='Zintrabi')
-
-        rows, total = self.search.search(self.session, {'skip': 1})
-
-        assert_that(total, equal_to(2))
-        assert_that(rows, contains(last_user_row))
-
     def test_given_search_without_accent_term_then_searches_in_column_with_accent(self):
         user_row = self.add_user(firstname='accênt')
 

--- a/xivo_dao/resources/voicemail/tests/test_dao.py
+++ b/xivo_dao/resources/voicemail/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -278,17 +278,17 @@ class TestSearchGivenMultipleVoicemail(TestSearch):
 
         self.assert_search_returns_result(expected, limit=1)
 
-    def test_when_skipping_then_returns_right_number_of_items(self):
+    def test_when_offset_then_returns_right_number_of_items(self):
         expected = SearchResult(4, [self.voicemail2, self.voicemail3, self.voicemail4])
 
-        self.assert_search_returns_result(expected, skip=1)
+        self.assert_search_returns_result(expected, offset=1)
 
     def test_when_doing_a_paginated_search_then_returns_a_paginated_result(self):
         expected = SearchResult(3, [self.voicemail2])
 
         self.assert_search_returns_result(
             expected,
-            search='a', order='name', direction='desc', skip=1, limit=1,
+            search='a', order='name', direction='desc', offset=1, limit=1,
         )
 
 


### PR DESCRIPTION
user: allow to search with multiple uuid
remove deprecated skip option for search
remove legacy user search