### PR TITLE
Pull request for WAZO-163-remove-dialaction-on-delete

### DIFF
--- a/xivo_dao/alchemy/application.py
+++ b/xivo_dao/alchemy/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.schema import (
@@ -30,3 +30,13 @@ class Application(Base):
     )
 
     lines = relationship('LineFeatures', viewonly=True)
+
+    _dialaction_actions = relationship(
+        'Dialaction',
+        primaryjoin="""and_(
+            Dialaction.action == 'application:custom',
+            Dialaction.actionarg1 == Application.uuid
+        )""",
+        foreign_keys='Dialaction.actionarg1',
+        cascade='all, delete-orphan',
+    )

--- a/xivo_dao/alchemy/conference.py
+++ b/xivo_dao/alchemy/conference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -62,11 +62,10 @@ class Conference(Base):
 
     incalls = association_proxy('incall_dialactions', 'incall')
 
-    ivr_dialactions = relationship(
+    _dialaction_actions = relationship(
         'Dialaction',
         primaryjoin="""and_(Dialaction.action == 'conference',
-                            Dialaction.actionarg1 == cast(Conference.id, String),
-                            Dialaction.category.in_(['ivr', 'ivr_choice']))""",
+                            Dialaction.actionarg1 == cast(Conference.id, String))""",
         foreign_keys='Dialaction.actionarg1',
         cascade='all, delete-orphan',
     )

--- a/xivo_dao/alchemy/dialaction.py
+++ b/xivo_dao/alchemy/dialaction.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column, PrimaryKeyConstraint, Index
-from sqlalchemy.types import Integer, String
+from sqlalchemy.types import String
 from sqlalchemy.sql import func
 
 from xivo_dao.helpers.db_manager import Base, IntAsString
@@ -39,7 +39,6 @@ class Dialaction(Base):
     action = Column(enum.dialaction_action, nullable=False)
     actionarg1 = Column(IntAsString(255))
     actionarg2 = Column(String(255))
-    linked = Column(Integer, nullable=False, server_default='0')
 
     conference = relationship(
         'Conference',
@@ -153,7 +152,6 @@ class Dialaction(Base):
                 action='none',
                 actionarg1=None,
                 actionarg2=None,
-                linked=1
             )
 
     @hybrid_property
@@ -191,6 +189,4 @@ class Dialaction(Base):
 
     @property
     def gosub_args(self):
-        if not self.linked:
-            return 'none'
         return ','.join(item or '' for item in (self.action, self.actionarg1, self.actionarg2))

--- a/xivo_dao/alchemy/groupfeatures.py
+++ b/xivo_dao/alchemy/groupfeatures.py
@@ -261,7 +261,6 @@ class GroupFeatures(Base):
 
             if event not in self.group_dialactions:
                 dialaction.category = 'group'
-                dialaction.linked = 1
                 dialaction.event = event
                 self.group_dialactions[event] = dialaction
 

--- a/xivo_dao/alchemy/groupfeatures.py
+++ b/xivo_dao/alchemy/groupfeatures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import six
@@ -116,11 +116,10 @@ class GroupFeatures(Base):
         passive_updates=False,
     )
 
-    ivr_dialactions = relationship(
+    _dialaction_actions = relationship(
         'Dialaction',
         primaryjoin="""and_(Dialaction.action == 'group',
-                            Dialaction.actionarg1 == cast(GroupFeatures.id, String),
-                            Dialaction.category.in_(['ivr', 'ivr_choice']))""",
+                            Dialaction.actionarg1 == cast(GroupFeatures.id, String))""",
         foreign_keys='Dialaction.actionarg1',
         cascade='all, delete-orphan',
     )

--- a/xivo_dao/alchemy/incall.py
+++ b/xivo_dao/alchemy/incall.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -113,7 +113,6 @@ class Incall(Base):
         if not self.dialaction:
             destination.event = 'answer'
             destination.category = 'incall'
-            destination.linked = 1
             self.dialaction = destination
 
         self.dialaction.action = destination.action

--- a/xivo_dao/alchemy/ivr.py
+++ b/xivo_dao/alchemy/ivr.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -60,12 +60,11 @@ class IVR(Base):
 
     incalls = association_proxy('incall_dialactions', 'incall')
 
-    ivr_dialactions = relationship(
-        'Dialaction',
+    _dialaction_actions = relationship(
+        Dialaction,
         primaryjoin="""and_(
             Dialaction.action == 'ivr',
             Dialaction.actionarg1 == cast(IVR.id, String),
-            Dialaction.category.in_(['ivr', 'ivr_choice'])
         )""",
         foreign_keys='Dialaction.actionarg1',
         cascade='all, delete-orphan',

--- a/xivo_dao/alchemy/ivr.py
+++ b/xivo_dao/alchemy/ivr.py
@@ -102,7 +102,6 @@ class IVR(Base):
         if event not in self.dialactions:
             dialaction.event = event
             dialaction.category = 'ivr'
-            dialaction.linked = 1
             self.dialactions[event] = dialaction
 
         self.dialactions[event].action = dialaction.action

--- a/xivo_dao/alchemy/ivr_choice.py
+++ b/xivo_dao/alchemy/ivr_choice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.orm import relationship
@@ -38,7 +38,6 @@ class IVRChoice(Base):
         if not self.dialaction:
             destination.event = 'ivr_choice'
             destination.category = 'ivr_choice'
-            destination.linked = 1
             self.dialaction = destination
 
         self.dialaction.action = destination.action

--- a/xivo_dao/alchemy/outcall.py
+++ b/xivo_dao/alchemy/outcall.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -74,11 +74,10 @@ class Outcall(Base):
         creator=lambda _trunk: OutcallTrunk(trunk=_trunk),
     )
 
-    ivr_dialactions = relationship(
+    _dialaction_actions = relationship(
         'Dialaction',
         primaryjoin="""and_(Dialaction.action == 'outcall',
-                            Dialaction.actionarg1 == cast(Outcall.id, String),
-                            Dialaction.category.in_(['ivr', 'ivr_choice']))""",
+                            Dialaction.actionarg1 == cast(Outcall.id, String))""",
         foreign_keys='Dialaction.actionarg1',
         cascade='all, delete-orphan',
     )

--- a/xivo_dao/alchemy/queuefeatures.py
+++ b/xivo_dao/alchemy/queuefeatures.py
@@ -242,7 +242,6 @@ class QueueFeatures(Base):
         if event not in self.queue_dialactions:
             dialaction.event = event
             dialaction.category = 'queue'
-            dialaction.linked = 1
             self.queue_dialactions[event] = dialaction
 
         self.queue_dialactions[event].action = dialaction.action

--- a/xivo_dao/alchemy/queuefeatures.py
+++ b/xivo_dao/alchemy/queuefeatures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import six
@@ -142,11 +142,10 @@ class QueueFeatures(Base):
         collection_class=attribute_mapped_collection('event'),
     )
 
-    ivr_dialactions = relationship(
+    _dialaction_actions = relationship(
         'Dialaction',
         primaryjoin="""and_(Dialaction.action == 'queue',
-                            Dialaction.actionarg1 == cast(QueueFeatures.id, String),
-                            Dialaction.category.in_(['ivr', 'ivr_choice']))""",
+                            Dialaction.actionarg1 == cast(QueueFeatures.id, String))""",
         foreign_keys='Dialaction.actionarg1',
         cascade='all, delete-orphan',
     )

--- a/xivo_dao/alchemy/switchboard.py
+++ b/xivo_dao/alchemy/switchboard.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -36,6 +36,16 @@ class Switchboard(Base):
     )
 
     incalls = association_proxy('incall_dialactions', 'incall')
+
+    _dialaction_actions = relationship(
+        'Dialaction',
+        primaryjoin="""and_(
+            Dialaction.action == 'switchboard',
+            Dialaction.actionarg1 == Switchboard.uuid
+        )""",
+        foreign_keys='Dialaction.actionarg1',
+        cascade='all, delete-orphan',
+    )
 
     switchboard_member_users = relationship(
         'SwitchboardMemberUser',

--- a/xivo_dao/alchemy/tests/test_conference.py
+++ b/xivo_dao/alchemy/tests/test_conference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (assert_that,
@@ -24,10 +24,12 @@ class TestIncalls(DAOTestCase):
 
 class TestDelete(DAOTestCase):
 
-    def test_ivr_dialactions_are_deleted(self):
+    def test_dialaction_actions_are_deleted(self):
         conference = self.add_conference()
         self.add_dialaction(category='ivr_choice', action='conference', actionarg1=conference.id)
         self.add_dialaction(category='ivr', action='conference', actionarg1=conference.id)
+        self.add_dialaction(category='user', action='conference', actionarg1=conference.id)
+        self.add_dialaction(category='incall', action='conference', actionarg1=conference.id)
 
         self.session.delete(conference)
         self.session.flush()

--- a/xivo_dao/alchemy/tests/test_dialaction.py
+++ b/xivo_dao/alchemy/tests/test_dialaction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -17,20 +17,14 @@ class TestGoSubArgs(unittest.TestCase):
     def test_getter(self):
         dialaction = Dialaction(action='extension',
                                 actionarg1='21',
-                                actionarg2='foobar',
-                                linked=1)
+                                actionarg2='foobar')
 
         assert_that(dialaction.gosub_args, equal_to('extension,21,foobar'))
 
     def test_getter_with_none(self):
-        dialaction = Dialaction(action='none', linked=1)
+        dialaction = Dialaction(action='none')
 
         assert_that(dialaction.gosub_args, equal_to('none,,'))
-
-    def test_getter_with_unlinked_dialaction(self):
-        dialaction = Dialaction(action='user', actionarg1='1', linked=0)
-
-        assert_that(dialaction.gosub_args, equal_to('none'))
 
 
 class TestType(unittest.TestCase):

--- a/xivo_dao/alchemy/tests/test_groupfeatures.py
+++ b/xivo_dao/alchemy/tests/test_groupfeatures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -460,10 +460,12 @@ class TestDelete(DAOTestCase, FuncKeyHelper):
         row = self.session.query(FuncKeyDestGroup).first()
         assert_that(row, none())
 
-    def test_ivr_dialactions_are_deleted(self):
+    def test_dialaction_actions_are_deleted(self):
         group = self.add_group()
         self.add_dialaction(category='ivr_choice', action='group', actionarg1=group.id)
         self.add_dialaction(category='ivr', action='group', actionarg1=group.id)
+        self.add_dialaction(category='user', action='group', actionarg1=group.id)
+        self.add_dialaction(category='incall', action='group', actionarg1=group.id)
 
         self.session.delete(group)
         self.session.flush()

--- a/xivo_dao/alchemy/tests/test_ivr.py
+++ b/xivo_dao/alchemy/tests/test_ivr.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, none
@@ -10,10 +10,12 @@ from xivo_dao.tests.test_dao import DAOTestCase
 
 class TestDelete(DAOTestCase):
 
-    def test_ivr_dialactions_are_deleted(self):
+    def test_dialaction_actions_are_deleted(self):
         ivr = self.add_ivr()
         self.add_dialaction(category='ivr_choice', action='ivr', actionarg1=ivr.id)
         self.add_dialaction(category='ivr', action='ivr', actionarg1=ivr.id)
+        self.add_dialaction(category='user', action='ivr', actionarg1=ivr.id)
+        self.add_dialaction(category='incall', action='ivr', actionarg1=ivr.id)
 
         self.session.delete(ivr)
         self.session.flush()

--- a/xivo_dao/alchemy/tests/test_outcall.py
+++ b/xivo_dao/alchemy/tests/test_outcall.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -93,10 +93,12 @@ class TestDelete(DAOTestCase):
         dialpattern = self.session.query(DialPattern).first()
         assert_that(dialpattern, none())
 
-    def test_ivr_dialactions_are_deleted(self):
+    def test_dialaction_actions_are_deleted(self):
         outcall = self.add_outcall()
         self.add_dialaction(category='ivr_choice', action='outcall', actionarg1=outcall.id)
         self.add_dialaction(category='ivr', action='outcall', actionarg1=outcall.id)
+        self.add_dialaction(category='user', action='outcall', actionarg1=outcall.id)
+        self.add_dialaction(category='incall', action='outcall', actionarg1=outcall.id)
 
         self.session.delete(outcall)
         self.session.flush()

--- a/xivo_dao/alchemy/tests/test_queuefeatures.py
+++ b/xivo_dao/alchemy/tests/test_queuefeatures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -621,10 +621,12 @@ class TestDelete(DAOTestCase, FuncKeyHelper):
         row = self.session.query(Dialaction).first()
         assert_that(row, none())
 
-    def test_ivr_dialactions_are_deleted(self):
+    def test_dialaction_actions_are_deleted(self):
         queue = self.add_queuefeatures()
         self.add_dialaction(category='ivr_choice', action='queue', actionarg1=queue.id)
         self.add_dialaction(category='ivr', action='queue', actionarg1=queue.id)
+        self.add_dialaction(category='user', action='queue', actionarg1=queue.id)
+        self.add_dialaction(category='incall', action='queue', actionarg1=queue.id)
 
         self.session.delete(queue)
         self.session.flush()

--- a/xivo_dao/alchemy/tests/test_queuefeatures.py
+++ b/xivo_dao/alchemy/tests/test_queuefeatures.py
@@ -105,7 +105,6 @@ class TestFallbacks(DAOTestCase):
         assert_that(queue.fallbacks['busy'], has_properties(
             action='none',
             category='queue',
-            linked=1,
             event='busy'
         ))
 
@@ -172,7 +171,6 @@ class TestWaitTimeDestination(DAOTestCase):
         assert_that(queue.wait_time_destination, has_properties(
             action='none',
             category='queue',
-            linked=1,
             event='qwaittime'
         ))
 
@@ -212,7 +210,6 @@ class TestWaitRatioDestination(DAOTestCase):
         assert_that(queue.wait_ratio_destination, has_properties(
             action='none',
             category='queue',
-            linked=1,
             event='qwaitratio'
         ))
 

--- a/xivo_dao/alchemy/tests/test_switchboard.py
+++ b/xivo_dao/alchemy/tests/test_switchboard.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import (
+    assert_that,
+    none,
+)
+
+from xivo_dao.alchemy.dialaction import Dialaction
+from xivo_dao.tests.test_dao import DAOTestCase
+
+
+class TestDelete(DAOTestCase):
+
+    def test_ivr_dialactions_are_deleted(self):
+        switchboard = self.add_switchboard()
+        self.add_dialaction(category='ivr_choice', action='switchboard', actionarg1=switchboard.uuid)
+        self.add_dialaction(category='ivr', action='switchboard', actionarg1=switchboard.uuid)
+        self.add_dialaction(category='user', action='switchboard', actionarg1=switchboard.uuid)
+        self.add_dialaction(category='incall', action='switchboard', actionarg1=switchboard.uuid)
+
+        self.session.delete(switchboard)
+        self.session.flush()
+
+        row = self.session.query(Dialaction).first()
+        assert_that(row, none())

--- a/xivo_dao/alchemy/tests/test_userfeatures.py
+++ b/xivo_dao/alchemy/tests/test_userfeatures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -772,10 +772,12 @@ class TestDelete(DAOTestCase):
         row = self.session.query(PagingUser).first()
         assert_that(row, none())
 
-    def test_ivr_dialactions_are_deleted(self):
+    def test_dialaction_actions_are_deleted(self):
         user = self.add_user()
         self.add_dialaction(category='ivr_choice', action='user', actionarg1=user.id)
         self.add_dialaction(category='ivr', action='user', actionarg1=user.id)
+        self.add_dialaction(category='user', action='user', actionarg1=user.id)
+        self.add_dialaction(category='incall', action='user', actionarg1=user.id)
 
         self.session.delete(user)
         self.session.flush()

--- a/xivo_dao/alchemy/tests/test_userfeatures.py
+++ b/xivo_dao/alchemy/tests/test_userfeatures.py
@@ -784,3 +784,13 @@ class TestDelete(DAOTestCase):
 
         row = self.session.query(Dialaction).first()
         assert_that(row, none())
+
+    def test_user_dialaction_are_deleted(self):
+        user = self.add_user()
+        self.add_dialaction(category='user', categoryval=str(user.id))
+
+        self.session.delete(user)
+        self.session.flush()
+
+        row = self.session.query(Dialaction).first()
+        assert_that(row, none())

--- a/xivo_dao/alchemy/tests/test_voicemail.py
+++ b/xivo_dao/alchemy/tests/test_voicemail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import and_
@@ -77,10 +77,12 @@ class TestUsers(DAOTestCase):
 
 class TestDelete(DAOTestCase):
 
-    def test_ivr_dialactions_are_deleted(self):
+    def test_dialaction_actions_are_deleted(self):
         voicemail = self.add_voicemail()
         self.add_dialaction(category='ivr_choice', action='voicemail', actionarg1=voicemail.id)
         self.add_dialaction(category='ivr', action='voicemail', actionarg1=voicemail.id)
+        self.add_dialaction(category='user', action='voicemail', actionarg1=voicemail.id)
+        self.add_dialaction(category='incall', action='voicemail', actionarg1=voicemail.id)
 
         self.session.delete(voicemail)
         self.session.flush()

--- a/xivo_dao/alchemy/userfeatures.py
+++ b/xivo_dao/alchemy/userfeatures.py
@@ -359,7 +359,6 @@ class UserFeatures(Base):
 
             if event not in self.user_dialactions:
                 dialaction.category = 'user'
-                dialaction.linked = 1
                 dialaction.event = event
                 self.user_dialactions[event] = dialaction
 

--- a/xivo_dao/alchemy/userfeatures.py
+++ b/xivo_dao/alchemy/userfeatures.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -223,12 +223,11 @@ class UserFeatures(Base):
     switchboard_member_users = relationship('SwitchboardMemberUser', cascade='all, delete-orphan')
     switchboards = association_proxy('switchboard_member_users', 'switchboard')
 
-    ivr_dialactions = relationship(
+    _dialaction_actions = relationship(
         'Dialaction',
         primaryjoin="""and_(
             Dialaction.action == 'user',
             Dialaction.actionarg1 == cast(UserFeatures.id, String),
-            Dialaction.category.in_(['ivr', 'ivr_choice'])
         )""",
         foreign_keys='Dialaction.actionarg1',
         cascade='all, delete-orphan',

--- a/xivo_dao/alchemy/voicemail.py
+++ b/xivo_dao/alchemy/voicemail.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import sql, Boolean
@@ -54,11 +54,10 @@ class Voicemail(Base):
 
     users = relationship('UserFeatures', back_populates='voicemail')
 
-    ivr_dialactions = relationship(
+    dialaction_actions = relationship(
         'Dialaction',
         primaryjoin="""and_(Dialaction.action == 'voicemail',
-                            Dialaction.actionarg1 == cast(Voicemail.id, String),
-                            Dialaction.category.in_(['ivr', 'ivr_choice']))""",
+                            Dialaction.actionarg1 == cast(Voicemail.id, String))""",
         foreign_keys='Dialaction.actionarg1',
         cascade='all, delete-orphan',
     )

--- a/xivo_dao/resources/call_filter/persistor.py
+++ b/xivo_dao/resources/call_filter/persistor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import text
@@ -101,7 +101,6 @@ class CallFilterPersistor(CriteriaBuilderMixin):
 
             if event not in call_filter.callfilter_dialactions:
                 dialaction.category = 'callfilter'
-                dialaction.linked = 1
                 dialaction.event = event
                 call_filter.callfilter_dialactions[event] = dialaction
 

--- a/xivo_dao/resources/conference/persistor.py
+++ b/xivo_dao/resources/conference/persistor.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import text
 
 from xivo_dao.alchemy.conference import Conference
-from xivo_dao.alchemy.dialaction import Dialaction
 
 from xivo_dao.helpers import errors
 from xivo_dao.resources.utils.search import SearchResult, CriteriaBuilderMixin
@@ -60,12 +59,6 @@ class ConferencePersistor(CriteriaBuilderMixin):
         self.session.flush()
 
     def _delete_associations(self, conference):
-        # "unlink" dialactions that points on this Conference
-        (self.session.query(Dialaction)
-         .filter(Dialaction.action == 'conference')
-         .filter(Dialaction.actionarg1 == str(conference.id))
-         .update({'linked': 0}))
-
         for extension in conference.extensions:
             extension.type = 'user'
             extension.typeval = '0'

--- a/xivo_dao/resources/conference/tests/test_dao.py
+++ b/xivo_dao/resources/conference/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -20,7 +20,6 @@ from hamcrest import (
 
 from xivo_dao.alchemy.conference import Conference
 from xivo_dao.alchemy.extension import Extension
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.resources.utils.search import SearchResult
 from xivo_dao.helpers.exception import (
     NotFoundError,
@@ -464,15 +463,6 @@ class TestDelete(DAOTestCase):
 
         row = self.session.query(Conference).first()
         assert_that(row, none())
-
-    def test_when_deleting_then_dialactions_are_unlinked(self):
-        conference = self.add_conference()
-        self.add_dialaction(action='conference', actionarg1=str(conference.id), linked=1)
-
-        conference_dao.delete(conference)
-
-        dialaction = self.session.query(Dialaction).filter(Dialaction.actionarg1 == str(conference.id)).first()
-        assert_that(dialaction, has_properties(linked=0))
 
     def test_when_deleting_then_extension_are_dissociated(self):
         conference = self.add_conference()

--- a/xivo_dao/resources/group/persistor.py
+++ b/xivo_dao/resources/group/persistor.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.orm import joinedload
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.groupfeatures import GroupFeatures as Group
 
 from xivo_dao.helpers import errors
@@ -79,11 +78,6 @@ class GroupPersistor(CriteriaBuilderMixin):
         self.session.flush()
 
     def _delete_associations(self, group):
-        (self.session.query(Dialaction)
-         .filter(Dialaction.action == 'group')
-         .filter(Dialaction.actionarg1 == str(group.id))
-         .update({'linked': 0}))
-
         for extension in group.extensions:
             extension.type = 'user'
             extension.typeval = '0'

--- a/xivo_dao/resources/group/tests/test_dao.py
+++ b/xivo_dao/resources/group/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -18,7 +18,6 @@ from hamcrest import (
 )
 from mock import Mock
 
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.extension import Extension
 from xivo_dao.alchemy.groupfeatures import GroupFeatures as Group
 from xivo_dao.alchemy.queue import Queue
@@ -500,15 +499,6 @@ class TestDelete(DAOTestCase):
 
         row = self.session.query(Schedule).first()
         assert_that(row.id, equal_to(schedule.id))
-
-    def test_when_deleting_then_dialactions_are_unlinked(self):
-        group = self.add_group()
-        self.add_dialaction(action='group', actionarg1=str(group.id), linked=1)
-
-        group_dao.delete(group)
-
-        dialaction = self.session.query(Dialaction).filter(Dialaction.actionarg1 == str(group.id)).first()
-        assert_that(dialaction, has_properties(linked=0))
 
 
 class TestAssociateMemberUsers(DAOTestCase):

--- a/xivo_dao/resources/ivr/persistor.py
+++ b/xivo_dao/resources/ivr/persistor.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import text
 
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.ivr import IVR
 from xivo_dao.helpers import errors
 from xivo_dao.resources.utils.search import CriteriaBuilderMixin, SearchResult
@@ -63,13 +62,5 @@ class IVRPersistor(CriteriaBuilderMixin):
         self.session.flush()
 
     def delete(self, ivr):
-        self._delete_associations(ivr)
         self.session.delete(ivr)
         self.session.flush()
-
-    def _delete_associations(self, ivr):
-        # "unlink" dialactions that points on this IVR
-        (self.session.query(Dialaction)
-         .filter(Dialaction.action == 'ivr')
-         .filter(Dialaction.actionarg1 == str(ivr.id))
-         .update({'linked': 0}))

--- a/xivo_dao/resources/ivr/tests/test_dao.py
+++ b/xivo_dao/resources/ivr/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -473,34 +473,6 @@ class TestDelete(DAOTestCase):
         ivr_dao.delete(ivr)
 
         assert_that(inspect(ivr).deleted)
-
-    def test_when_deleting_then_dialactions_are_deleted(self):
-        ivr = self.add_ivr()
-        self.add_dialaction(event='timeout', category='ivr', categoryval=str(ivr.id))
-
-        ivr_dao.delete(ivr)
-
-        dialaction = self.session.query(Dialaction).first()
-        assert_that(dialaction, none())
-
-    def test_when_deleting_then_choices_are_deleted(self):
-        ivr = self.add_ivr()
-        ivr_choice = self.add_ivr_choice(ivr_id=ivr.id)
-        self.add_dialaction(category='ivr_choice', categoryval=str(ivr_choice.id))
-
-        ivr_dao.delete(ivr)
-
-        assert_that(self.session.query(IVRChoice).first(), none())
-        assert_that(self.session.query(Dialaction).first(), none())
-
-    def test_when_deleting_then_dialactions_are_unlinked(self):
-        ivr = self.add_ivr()
-        self.add_dialaction(action='ivr', actionarg1=str(ivr.id), linked=1)
-
-        ivr_dao.delete(ivr)
-
-        dialaction = self.session.query(Dialaction).filter(Dialaction.actionarg1 == str(ivr.id)).first()
-        assert_that(dialaction, has_properties(linked=0))
 
 
 class TestRelationship(DAOTestCase):

--- a/xivo_dao/resources/queue/persistor.py
+++ b/xivo_dao/resources/queue/persistor.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.orm import joinedload
 from xivo_dao.alchemy.contextmember import ContextMember
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.queuefeatures import QueueFeatures as Queue
 
 from xivo_dao.helpers import errors
@@ -80,11 +79,6 @@ class QueuePersistor(CriteriaBuilderMixin):
          .filter(ContextMember.type == 'queue')
          .filter(ContextMember.typeval == str(queue.id))
          .delete())
-
-        (self.session.query(Dialaction)
-         .filter(Dialaction.action == 'queue')
-         .filter(Dialaction.actionarg1 == str(queue.id))
-         .update({'linked': 0}))
 
         for extension in queue.extensions:
             extension.type = 'user'

--- a/xivo_dao/resources/queue/tests/test_dao.py
+++ b/xivo_dao/resources/queue/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -18,7 +18,6 @@ from hamcrest import (
 from sqlalchemy.inspection import inspect
 
 from xivo_dao.alchemy.agentfeatures import AgentFeatures
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.extension import Extension
 from xivo_dao.alchemy.queuefeatures import QueueFeatures
 from xivo_dao.alchemy.queue import Queue
@@ -521,15 +520,6 @@ class TestDelete(DAOTestCase):
         row = self.session.query(Extension).first()
         assert_that(row.id, equal_to(extension.id))
         assert_that(row, has_properties(type='user', typeval='0'))
-
-    def test_when_deleting_then_dialactions_are_unlinked(self):
-        queue = self.add_queuefeatures()
-        self.add_dialaction(action='queue', actionarg1=str(queue.id), linked=1)
-
-        queue_dao.delete(queue)
-
-        dialaction = self.session.query(Dialaction).filter(Dialaction.actionarg1 == str(queue.id)).first()
-        assert_that(dialaction, has_properties(linked=0))
 
     def test_when_deleting_then_contextmember_are_dissociated(self):
         queue = self.add_queuefeatures()

--- a/xivo_dao/resources/user/persistor.py
+++ b/xivo_dao/resources/user/persistor.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.userfeatures import UserFeatures as User
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.func_key_template import FuncKeyTemplate
 from xivo_dao.helpers.db_manager import Session
 
@@ -92,9 +91,6 @@ class UserPersistor(CriteriaBuilderMixin):
         self.session.flush()
 
     def delete(self, user):
-        (self.session.query(Dialaction).filter(Dialaction.category == 'user')
-         .filter(Dialaction.categoryval == str(user.id))
-         .delete())
         self.session.delete(user)
         self.session.flush()
 

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -21,12 +21,10 @@ from hamcrest import (
 )
 
 from xivo_dao.alchemy.callfiltermember import Callfiltermember
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.func_key import FuncKey
 from xivo_dao.alchemy.func_key_dest_user import FuncKeyDestUser
 from xivo_dao.alchemy.func_key_template import FuncKeyTemplate
 from xivo_dao.alchemy.groupfeatures import GroupFeatures
-from xivo_dao.alchemy.ivr_choice import IVRChoice
 from xivo_dao.alchemy.queuemember import QueueMember
 from xivo_dao.alchemy.rightcallmember import RightCallMember
 from xivo_dao.alchemy.schedulepath import SchedulePath
@@ -889,21 +887,15 @@ class TestDelete(TestUser):
         self.add_schedule_path(schedule_id=schedule.id, path='user', pathid=user.id)
         call_filter = self.add_bsfilter()
         self.add_filter_member(call_filter.id, user.id)
-        ivr = self.add_ivr()
-        self.add_dialaction(category='ivr', categoryval=ivr.id, action='user', actionarg1=user.id)
-        ivr_choice = self.add_ivr_choice(ivr_id=ivr.id)
-        self.add_dialaction(category='ivr_choice', categoryval=ivr_choice.id, action='user', actionarg1=user.id)
 
         user_dao.delete(user)
 
         assert_that(self.session.query(RightCallMember).first(), none())
-        assert_that(self.session.query(Dialaction).first(), none())
         assert_that(self.session.query(SchedulePath).first(), none())
         assert_that(self.session.query(Callfiltermember).first(), none())
         assert_that(self.session.query(FuncKeyDestUser).first(), none())
         assert_that(self.session.query(FuncKey).first(), none())
         assert_that(self.session.query(FuncKeyTemplate).first(), none())
-        assert_that(self.session.query(IVRChoice).first(), none())
 
 
 class TestAssociateGroups(DAOTestCase):

--- a/xivo_dao/resources/user/view.py
+++ b/xivo_dao/resources/user/view.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.orm import joinedload
@@ -46,7 +46,6 @@ class UserView(View):
                 .options(joinedload('group_members'))
                 .options(joinedload('queue_members'))
                 .options(joinedload('switchboard_member_users'))
-                .options(joinedload('ivr_dialactions'))
                 .options(joinedload('schedule_paths'))
                 .options(joinedload('rightcall_members'))
                 .options(joinedload('voicemail')))

--- a/xivo_dao/resources/voicemail/persistor.py
+++ b/xivo_dao/resources/voicemail/persistor.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import text
 
 from xivo_dao.alchemy.voicemail import Voicemail
-from xivo_dao.alchemy.dialaction import Dialaction
 
 from xivo_dao.helpers import errors
 from xivo_dao.resources.utils.search import SearchResult, CriteriaBuilderMixin
@@ -55,15 +54,8 @@ class VoicemailPersistor(CriteriaBuilderMixin):
         self.session.flush()
 
     def delete(self, voicemail):
-        self._delete_associations(voicemail)
         self.session.delete(voicemail)
         self.session.flush()
-
-    def _delete_associations(self, voicemail):
-        (self.session.query(Dialaction)
-         .filter(Dialaction.action == 'voicemail')
-         .filter(Dialaction.actionarg1 == str(voicemail.id))
-         .update({'linked': 0}))
 
     def _filter_tenant_uuid(self, query):
         if self.tenant_uuids is None:

--- a/xivo_dao/resources/voicemail/tests/test_dao.py
+++ b/xivo_dao/resources/voicemail/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -16,7 +16,6 @@ from hamcrest import (
     not_,
 )
 
-from xivo_dao.alchemy.dialaction import Dialaction
 from xivo_dao.alchemy.voicemail import Voicemail
 from xivo_dao.tests.test_dao import DAOTestCase
 from xivo_dao.resources.voicemail import dao as voicemail_dao
@@ -509,12 +508,3 @@ class TestDelete(DAOTestCase):
 
         row = self.session.query(Voicemail).first()
         assert_that(row, none())
-
-    def test_when_deleting_then_dialactions_are_unlinked(self):
-        voicemail = self.add_ivr()
-        self.add_dialaction(action='voicemail', actionarg1=str(voicemail.id), linked=1)
-
-        voicemail_dao.delete(voicemail)
-
-        dialaction = self.session.query(Dialaction).first()
-        assert_that(dialaction, has_properties(linked=0))


### PR DESCRIPTION
remove unused linked from dialaction
switchboard: delete all dialaction when deleted
application: delete all dialaction when deleted
conference: delete all dialaction when deleted
outcall: delete all dialaction when deleted
voicemail: deleted all dialaction when deleted
queue: delete all dialaction when deleted
group: delete all dialaction when deleted
user: avoid duplicate deletion
user: delete all dialaction when deleted
ivr: delete all dialaction when delete IVR