### PR TITLE
generate hints for all users

### DIFF
--- a/xivo_dao/resources/func_key/hint_dao.py
+++ b/xivo_dao/resources/func_key/hint_dao.py
@@ -131,8 +131,6 @@ def _list_user_extensions(session, context):
         LineExtension, UserLine.line_id == LineExtension.line_id,
     ).join(
         Extension, LineExtension.extension_id == Extension.id,
-    ).join(
-        FuncKeyDestUser, FuncKeyDestUser.user_id == UserFeatures.id,
     ).filter(and_(
         UserLine.main_user.is_(True),
         LineExtension.main_extension.is_(True),


### PR DESCRIPTION
generate an hint event if there's no user with a funckey pointing at you.

The old behaviour was to create the destination for each user even when there
was no function key. That destination has been removed