### PR TITLE
asterisk_conf_dao: fix missing sccp device ID in line config

### DIFF
--- a/xivo_dao/asterisk_conf_dao.py
+++ b/xivo_dao/asterisk_conf_dao.py
@@ -104,6 +104,7 @@ def find_sccp_line_settings(session):
         ) = args
 
         line = {
+            'id': endpoint_sccp_id,
             'name': name,
             'cid_name': cid_name,
             'cid_num': cid_num,


### PR DESCRIPTION
```
2020-09-17 10:53:35,051 [12975] (ERROR) (wazo_confgend.confgen): unexpected error raised by handler
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/wazo_confgend/confgen.py", line 96, in _generate_and_cache
    content = handler()
  File "/usr/lib/python2.7/dist-packages/wazo_confgend/asterisk.py", line 33, in sccp_conf
    return self._generate_conf_from_generator(config_generator)
  File "/usr/lib/python2.7/dist-packages/wazo_confgend/asterisk.py", line 51, in _generate_conf_from_generator
    config_generator.generate(output)
  File "/usr/lib/python2.7/dist-packages/wazo_confgend/generators/sccp.py", line 33, in generate
    sccp_line_conf.generate(self._sccpline, splitted_settings.line_items, output)
  File "/usr/lib/python2.7/dist-packages/wazo_confgend/generators/sccp.py", line 127, in generate
    self._generate_lines(sccplines, output)
  File "/usr/lib/python2.7/dist-packages/wazo_confgend/generators/sccp.py", line 168, in _generate_lines
    print >> output, format_ast_option('setvar', 'WAZO_LINE_ID=%s' % item['id'])
KeyError: 'id'
```