### PR TITLE
stat queue/agent: flush session after adding item

### DIFF
--- a/xivo_dao/stat_agent_dao.py
+++ b/xivo_dao/stat_agent_dao.py
@@ -19,6 +19,7 @@ def insert_missing_agents(session, confd_agents):
         new_agent.tenant_uuid = agents_by_name[agent_name]['tenant_uuid']
         new_agent.agent_id = agents_by_name[agent_name]['id']
         session.add(new_agent)
+        session.flush()
 
 
 def clean_table(session):

--- a/xivo_dao/stat_queue_dao.py
+++ b/xivo_dao/stat_queue_dao.py
@@ -35,6 +35,7 @@ def insert_if_missing(session, queuelog_queues, confd_queues, master_tenant):
         new_queue.tenant_uuid = queue.get('tenant_uuid') or master_tenant
         new_queue.queue_id = queue.get('id')
         session.add(new_queue)
+        session.flush()
 
     active_queue_ids = set([queue['id'] for queue in confd_queues])
     all_queue_ids = set(r[0] for r in session.query(distinct(StatQueue.queue_id)))


### PR DESCRIPTION
reason: it can be hard to debug if flush occur on commit (or via
autoflush). It's good practice to flush after adding an item