### PR TITLE
WAZO-2059-refactor-online-call-record

### DIFF
--- a/xivo_dao/asterisk_conf_dao.py
+++ b/xivo_dao/asterisk_conf_dao.py
@@ -102,6 +102,7 @@ def find_sccp_line_settings(session):
             context,
             number,
             uuid,
+            enable_online_recording,
         ) = args
 
         line = {
@@ -115,6 +116,7 @@ def find_sccp_line_settings(session):
             'language': language,
             'uuid': uuid,
             'tenant_uuid': tenant_uuid,
+            'enable_online_recording': enable_online_recording,
         }
 
         if allow:
@@ -139,6 +141,7 @@ def find_sccp_line_settings(session):
         LineFeatures.context,
         Extension.exten,
         UserFeatures.uuid,
+        UserFeatures.enableonlinerec,
     ).join(LineFeatures, and_(
         LineFeatures.endpoint_sccp_id == SCCPLine.id,
     )).join(
@@ -483,6 +486,10 @@ def find_sip_user_settings(session):
                 # TODO(pc-m): document WAZO_USER_UUID and deprecate the XIVO one
                 # ['set_var', 'WAZO_USER_UUID={}'.format(user.uuid)],
             ])
+            if user.enableonlinerec:
+                base_config['endpoint_section_options'].append(
+                    ['set_var', 'DYNAMIC_FEATURES=togglerecord'],
+                )
         line_id = line_mapping.get(endpoint.uuid)
         if line_id:
             base_config['endpoint_section_options'].append(

--- a/xivo_dao/resources/features/dao.py
+++ b/xivo_dao/resources/features/dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.features import Features
@@ -43,4 +43,10 @@ def get_value(session, feature_id):
     if not value:
         raise errors.not_found('Features', id=feature_id)
 
+    value = _extract_applicationmap_dtmf(value)
+
     return value
+
+
+def _extract_applicationmap_dtmf(value):
+    return value.split(',', 1)[0]

--- a/xivo_dao/resources/features/search.py
+++ b/xivo_dao/resources/features/search.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-FUNC_KEY_FEATUREMAP_FOREIGN_KEY = ['blindxfer', 'automixmon', 'atxfer']
+FUNC_KEY_FEATUREMAP_FOREIGN_KEY = ['blindxfer', 'atxfer']
+FUNC_KEY_APPLICATIONMAP_FOREIGN_KEY = ['togglerecord']
 
 PARKING_OPTIONS = [
     'comebacktoorigin',

--- a/xivo_dao/resources/features/tests/test_dao.py
+++ b/xivo_dao/resources/features/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2015-2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -101,13 +101,14 @@ class TestEditAll(DAOTestCase):
     def test_does_not_change_foreign_key_id(self):
         feature1 = self.add_features(category='featuremap', var_name='blindxfer', var_val='value1')
         feature2 = self.add_features(category='featuremap', var_name='atxfer', var_val='value2')
-        feature3 = self.add_features(category='featuremap', var_name='automixmon', var_val='value3')
+        feature3 = self.add_features(category='applicationmap', var_name='togglerecord', var_val='value3')
 
         row1 = Features(var_name='blindxfer', var_val='other_value1')
         row2 = Features(var_name='atxfer', var_val='other_value2')
-        row3 = Features(var_name='automixmon', var_val='other_value3')
+        row3 = Features(var_name='togglerecord', var_val='other_value3')
 
-        features_dao.edit_all('featuremap', [row1, row2, row3])
+        features_dao.edit_all('featuremap', [row1, row2])
+        features_dao.edit_all('applicationmap', [row3])
 
         features = features_dao.find_all('featuremap')
         assert_that(features, contains_inanyorder(
@@ -115,6 +116,9 @@ class TestEditAll(DAOTestCase):
                            var_val=row1.var_val),
             has_properties(id=feature2.id,
                            var_val=row2.var_val),
+        ))
+        features = features_dao.find_all('applicationmap')
+        assert_that(features, contains_inanyorder(
             has_properties(id=feature3.id,
                            var_val=row3.var_val),
         ))

--- a/xivo_dao/resources/func_key_template/persistor.py
+++ b/xivo_dao/resources/func_key_template/persistor.py
@@ -649,7 +649,7 @@ class FeaturesPersistor(DestinationPersistor):
 
         if result.var_name == 'parkext':
             return FuncKeyDestParking(feature_id=result.id)
-        elif result.var_name == 'automixmon':
+        elif result.var_name == 'togglerecord':
             return FuncKeyDestOnlineRecording(feature_id=result.id)
 
         transfer = self.TRANSFERS_TO_API[result.var_name]
@@ -671,7 +671,7 @@ class FeaturesPersistor(DestinationPersistor):
         elif destination.type == 'parking':
             return 'parkext'
         elif destination.type == 'onlinerec':
-            return 'automixmon'
+            return 'togglerecord'
 
     def delete(self, func_key_id):
         pass

--- a/xivo_dao/resources/func_key_template/tests/test_dao.py
+++ b/xivo_dao/resources/func_key_template/tests/test_dao.py
@@ -308,7 +308,7 @@ class TestCreate(TestDao):
         self.assert_mapping_has_destination('features', destination_row)
 
     def test_given_template_has_onlinerec_destination_when_creating_then_creates_mapping(self):
-        destination_row = self.create_features_func_key('features.conf', 'automixmon', '*3')
+        destination_row = self.create_features_func_key('applicationmap', 'togglerecord', '*3,self,AGI(localhost,...)')
 
         template = self.build_template_with_key(FuncKeyDestOnlineRecording())
 


### PR DESCRIPTION
## asterisk_conf_dao: get online recording

Why:

* confgend needs this information to generate endpoint variables

## features: allow funckey destination to applicationmap

Why:

* applicationmap has a value format: name = *3,self,NoOp(my application)
* featuremap has value format: *3

## features: rename automixmon to togglerecord