### PR TITLE
stat_agent: allow to recreate agent with deleted agent number

### DIFF
--- a/xivo_dao/stat_agent_dao.py
+++ b/xivo_dao/stat_agent_dao.py
@@ -3,23 +3,96 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import distinct
+from sqlalchemy.sql.expression import or_
 
 from xivo_dao.alchemy.stat_agent import StatAgent
 
 
-def insert_missing_agents(session, confd_agents):
-    old_agents = set(r[0] for r in session.query(distinct(StatAgent.name)))
-    agents_by_name = {'Agent/{number}'.format(number=agent['number']): agent for agent in confd_agents}
-    configured_agents = set(agents_by_name)
+def insert_missing_agents(session, agentlog_agents, confd_agents, master_tenant):
+    confd_agents_by_name = {
+        'Agent/{number}'.format(number=agent['number']): agent for agent in confd_agents
+    }
+    _mark_recreated_agents_with_same_number_as_deleted(session, confd_agents_by_name)
+    _mark_non_confd_agents_as_deleted(session, confd_agents)
+    _create_missing_agents(session, agentlog_agents, confd_agents_by_name, master_tenant)
+    _rename_deleted_agents_with_duplicate_name(session, confd_agents_by_name)
 
-    missing_agents = configured_agents - old_agents
+
+def _mark_recreated_agents_with_same_number_as_deleted(session, confd_agents_by_name):
+    db_agent_query = session.query(StatAgent).filter(StatAgent.deleted.is_(False))
+    db_agents_by_name = {agent.name: agent for agent in db_agent_query.all()}
+
+    confd_agent_names = set(list(confd_agents_by_name.keys()))
+    db_agent_names = set(list(db_agents_by_name.keys()))
+
+    not_missing_agents = confd_agent_names.intersection(db_agent_names)
+    for agent_name in not_missing_agents:
+        confd_agent = confd_agents_by_name[agent_name]
+        db_agent = db_agents_by_name[agent_name]
+        if db_agent.agent_id != confd_agent['id']:
+            db_agent.deleted = True
+            session.flush()
+
+
+def _mark_non_confd_agents_as_deleted(session, confd_agents):
+    active_agent_ids = set([agent['id'] for agent in confd_agents])
+    all_agent_ids = set(r[0] for r in session.query(distinct(StatAgent.agent_id)))
+    deleted_agents = [agent for agent in list(all_agent_ids - active_agent_ids) if agent]
+    (
+        session.query(StatAgent)
+        .filter(
+            or_(
+                StatAgent.agent_id.in_(deleted_agents),
+                StatAgent.agent_id.is_(None),
+            )
+        )
+        .update({'deleted': True}, synchronize_session=False)
+
+    )
+    session.flush()
+
+
+def _create_missing_agents(session, agentlog_agents, confd_agents_by_name, master_tenant):
+    new_agent_names = set(confd_agents_by_name.keys())
+    db_agent_query = session.query(StatAgent).filter(StatAgent.deleted.is_(False))
+    old_agent_names = set(agent.name for agent in db_agent_query.all())
+    missing_agents = list(new_agent_names - old_agent_names)
+    for agent_name in missing_agents:
+        agent = confd_agents_by_name[agent_name]
+        new_agent = StatAgent()
+        new_agent.name = agent_name
+        new_agent.tenant_uuid = agent['tenant_uuid']
+        new_agent.agent_id = agent['id']
+        new_agent.deleted = False
+        session.add(new_agent)
+        session.flush()
+
+    db_agent_query = session.query(StatAgent).filter(StatAgent.deleted.is_(True))
+    old_agent_names = set(agent.name for agent in db_agent_query.all())
+    missing_agents = list(set(agentlog_agents) - old_agent_names - new_agent_names)
     for agent_name in missing_agents:
         new_agent = StatAgent()
         new_agent.name = agent_name
-        new_agent.tenant_uuid = agents_by_name[agent_name]['tenant_uuid']
-        new_agent.agent_id = agents_by_name[agent_name]['id']
+        new_agent.tenant_uuid = master_tenant
+        new_agent.deleted = True
         session.add(new_agent)
         session.flush()
+
+
+def _rename_deleted_agents_with_duplicate_name(session, confd_agents_by_name):
+    db_agent_query = session.query(StatAgent).filter(StatAgent.deleted.is_(True))
+    for agent in db_agent_query.all():
+        if agent.name in confd_agents_by_name:
+            agent.name = _find_next_available_name(session, agent.name)
+            session.flush()
+
+
+def _find_next_available_name(session, name):
+    query = session.query(StatAgent).filter(StatAgent.name == name)
+    if query.first():
+        next_name = '{}_'.format(name)
+        return _find_next_available_name(session, next_name)
+    return name
 
 
 def clean_table(session):

--- a/xivo_dao/tests/test_stat_agent_dao.py
+++ b/xivo_dao/tests/test_stat_agent_dao.py
@@ -2,6 +2,8 @@
 # Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import uuid
+
 from xivo_dao import stat_agent_dao
 from xivo_dao.alchemy.stat_agent import StatAgent
 from xivo_dao.helpers.db_utils import flush_session
@@ -18,53 +20,143 @@ class TestStatAgentDAO(DAOTestCase):
         self.assertTrue(self.session.query(StatAgent).first() is None)
 
     def test_insert_missing_agents(self):
+        # 1: in confd + in cel + in stat
+        # 2: in confd + not in cel + in stat
+        # 3: in confd + not in cel + not in stat',
+        # 4: in confd + in cel + not in stat',
+        # 5: not in confd + in cel + not in stat',
+        # 6: not in confd + in cel + in stat',
+        # 7: not in confd + not in cel + in stat',
         confd_agents = [
             {
                 'id': 1,
-                'number': 'number1',
+                'number': '1',
                 'tenant_uuid': 'tenant1',
             },
             {
                 'id': 2,
-                'number': 'number2',
+                'number': '2',
                 'tenant_uuid': 'tenant2',
             },
             {
                 'id': 3,
-                'number': 'number3',
+                'number': '3',
                 'tenant_uuid': 'tenant3',
             },
             {
                 'id': 4,
-                'number': 'number4',
+                'number': '4',
                 'tenant_uuid': 'tenant4',
             },
         ]
-        self._insert_agent('Agent/number1', 'tenant1', 1)
-        self._insert_agent('Agent/number2', 'tenant2', 2)
+        self._insert_agent('Agent/1', 'tenant1', 1)
+        self._insert_agent('Agent/2', 'tenant2', 2)
+        self._insert_agent('Agent/6', 'tenant6', 6)
+        self._insert_agent('Agent/7', 'tenant7', 7)
+
+        new_agents = ['Agent/1', 'Agent/4', 'Agent/5']
+        master_tenant = str(uuid.uuid4())
 
         with flush_session(self.session):
-            stat_agent_dao.insert_missing_agents(self.session, confd_agents)
+            stat_agent_dao.insert_missing_agents(self.session, new_agents, confd_agents, master_tenant)
 
-        result = [
-            (name, tenant_uuid, agent_id)
-            for name, tenant_uuid, agent_id
+        result = self._fetch_stat_agents()
+        self.assertTrue(('Agent/1', 'tenant1', 1, False) in result)
+        self.assertTrue(('Agent/2', 'tenant2', 2, False) in result)
+        self.assertTrue(('Agent/3', 'tenant3', 3, False) in result)
+        self.assertTrue(('Agent/4', 'tenant4', 4, False) in result)
+        self.assertTrue(('Agent/5', master_tenant, None, True) in result)
+        self.assertTrue(('Agent/6', 'tenant6', 6, True) in result)
+        self.assertTrue(('Agent/7', 'tenant7', 7, True) in result)
+        self.assertEquals(len(result), 7)
+
+    def test_when_agent_marked_as_deleted_then_new_one_is_created(self):
+        confd_agents = [{'id': 1, 'number': '1', 'tenant_uuid': 'tenant'}]
+        self._insert_agent('Agent/1', 'tenant', agent_id=999, deleted=True)
+        new_agents = ['Agent/1']
+        master_tenant = str(uuid.uuid4())
+
+        with flush_session(self.session):
+            stat_agent_dao.insert_missing_agents(self.session, new_agents, confd_agents, master_tenant)
+
+        result = self._fetch_stat_agents()
+        self.assertTrue(('Agent/1', 'tenant', 1, False) in result)
+        self.assertTrue(('Agent/1_', 'tenant', 999, True) in result)
+        self.assertEquals(len(result), 2)
+
+    def test_mark_recreated_agents_with_same_number_as_deleted(self):
+        confd_agents = {'Agent/1': {'id': 1, 'number': '1', 'tenant_uuid': 'tenant'}}
+        self._insert_agent('Agent/1', 'tenant', agent_id=999, deleted=False)
+
+        with flush_session(self.session):
+            stat_agent_dao._mark_recreated_agents_with_same_number_as_deleted(self.session, confd_agents)
+
+        result = self._fetch_stat_agents()
+        self.assertTrue(('Agent/1', 'tenant', 999, True) in result)
+        self.assertEquals(len(result), 1)
+
+    def test_mark_non_confd_agents_as_deleted(self):
+        confd_agents = [{'id': 1, 'number': '1', 'tenant_uuid': 'tenant'}]
+        self._insert_agent('Agent/2', 'tenant', agent_id=2, deleted=False)
+        self._insert_agent('Agent/3', 'tenant', agent_id=None, deleted=False)
+
+        with flush_session(self.session):
+            stat_agent_dao._mark_non_confd_agents_as_deleted(self.session, confd_agents)
+
+        result = self._fetch_stat_agents()
+        self.assertTrue(('Agent/2', 'tenant', 2, True) in result)
+        self.assertTrue(('Agent/3', 'tenant', None, True) in result)
+        self.assertEquals(len(result), 2)
+
+    def test_create_missing_agents(self):
+        confd_agents = {
+            'Agent/1': {'id': 1, 'number': '1', 'tenant_uuid': 'tenant'},
+        }
+        new_agents = ['Agent/2', 'Agent/3']
+        master_tenant = str(uuid.uuid4())
+        self._insert_agent('Agent/3', 'tenant', deleted=True)
+
+        with flush_session(self.session):
+            stat_agent_dao._create_missing_agents(
+                self.session, new_agents, confd_agents, master_tenant
+            )
+
+        result = self._fetch_stat_agents()
+        self.assertTrue(('Agent/1', 'tenant', 1, False) in result)
+        self.assertTrue(('Agent/2', master_tenant, None, True) in result)
+        self.assertTrue(('Agent/3', 'tenant', None, True) in result)
+        self.assertEquals(len(result), 3)
+
+    def test_rename_deleted_agents_with_duplicate_name(self):
+        confd_agents = {'Agent/1': {'id': 1, 'number': 'agent', 'tenant_uuid': 'tenant'}}
+        self._insert_agent('Agent/1', 'tenant', agent_id=1, deleted=True)
+        self._insert_agent('Agent/1', 'tenant', agent_id=1, deleted=True)
+
+        with flush_session(self.session):
+            stat_agent_dao._rename_deleted_agents_with_duplicate_name(
+                self.session, confd_agents
+            )
+
+        result = self._fetch_stat_agents()
+        self.assertTrue(('Agent/1_', 'tenant', 1, True) in result)
+        self.assertTrue(('Agent/1__', 'tenant', 1, True) in result)
+        self.assertEquals(len(result), 2)
+
+    def _fetch_stat_agents(self):
+        return [
+            (name, tenant_uuid, agent_id, deleted)
+            for name, tenant_uuid, agent_id, deleted
             in self.session.query(
-                StatAgent.name, StatAgent.tenant_uuid, StatAgent.agent_id
+                StatAgent.name, StatAgent.tenant_uuid, StatAgent.agent_id, StatAgent.deleted
             ).all()
         ]
 
-        self.assertTrue(('Agent/number1', 'tenant1', 1) in result)
-        self.assertTrue(('Agent/number2', 'tenant2', 2) in result)
-        self.assertTrue(('Agent/number3', 'tenant3', 3) in result)
-        self.assertTrue(('Agent/number4', 'tenant4', 4) in result)
-        self.assertEquals(len(result), 4)
-
-    def _insert_agent(self, name, tenant_uuid=None, agent_id=None):
+    def _insert_agent(self, name, tenant_uuid=None, agent_id=None, deleted=False):
         agent = StatAgent()
         agent.name = name
         agent.tenant_uuid = tenant_uuid or self.default_tenant.uuid
         agent.agent_id = agent_id
+        agent.deleted = deleted
 
         self.add_me(agent)
 


### PR DESCRIPTION
For now, we don't want to deleted statistic when agent is deleted, but
new agent can use an old deleted agent number. Then to avoid weird issue
with stat generator, deleted agent are renamed and marked as deleted