### PR TITLE
fix copy/paste create_missing_agents

### DIFF
--- a/xivo_dao/tests/test_stat_agent_dao.py
+++ b/xivo_dao/tests/test_stat_agent_dao.py
@@ -2,8 +2,6 @@
 # Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import uuid
-
 from xivo_dao import stat_agent_dao
 from xivo_dao.alchemy.stat_agent import StatAgent
 from xivo_dao.helpers.db_utils import flush_session
@@ -20,13 +18,9 @@ class TestStatAgentDAO(DAOTestCase):
         self.assertTrue(self.session.query(StatAgent).first() is None)
 
     def test_insert_missing_agents(self):
-        # 1: in confd + in cel + in stat
-        # 2: in confd + not in cel + in stat
-        # 3: in confd + not in cel + not in stat',
-        # 4: in confd + in cel + not in stat',
-        # 5: not in confd + in cel + not in stat',
-        # 6: not in confd + in cel + in stat',
-        # 7: not in confd + not in cel + in stat',
+        # 1: in confd + in stat
+        # 2: in confd + not in stat',
+        # 3: not in confd + in stat',
         confd_agents = [
             {
                 'id': 1,
@@ -38,46 +32,25 @@ class TestStatAgentDAO(DAOTestCase):
                 'number': '2',
                 'tenant_uuid': 'tenant2',
             },
-            {
-                'id': 3,
-                'number': '3',
-                'tenant_uuid': 'tenant3',
-            },
-            {
-                'id': 4,
-                'number': '4',
-                'tenant_uuid': 'tenant4',
-            },
         ]
         self._insert_agent('Agent/1', 'tenant1', 1)
-        self._insert_agent('Agent/2', 'tenant2', 2)
-        self._insert_agent('Agent/6', 'tenant6', 6)
-        self._insert_agent('Agent/7', 'tenant7', 7)
-
-        new_agents = ['Agent/1', 'Agent/4', 'Agent/5']
-        master_tenant = str(uuid.uuid4())
+        self._insert_agent('Agent/3', 'tenant3', 3)
 
         with flush_session(self.session):
-            stat_agent_dao.insert_missing_agents(self.session, new_agents, confd_agents, master_tenant)
+            stat_agent_dao.insert_missing_agents(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
         self.assertTrue(('Agent/1', 'tenant1', 1, False) in result)
         self.assertTrue(('Agent/2', 'tenant2', 2, False) in result)
-        self.assertTrue(('Agent/3', 'tenant3', 3, False) in result)
-        self.assertTrue(('Agent/4', 'tenant4', 4, False) in result)
-        self.assertTrue(('Agent/5', master_tenant, None, True) in result)
-        self.assertTrue(('Agent/6', 'tenant6', 6, True) in result)
-        self.assertTrue(('Agent/7', 'tenant7', 7, True) in result)
-        self.assertEquals(len(result), 7)
+        self.assertTrue(('Agent/3', 'tenant3', 3, True) in result)
+        self.assertEquals(len(result), 3)
 
     def test_when_agent_marked_as_deleted_then_new_one_is_created(self):
         confd_agents = [{'id': 1, 'number': '1', 'tenant_uuid': 'tenant'}]
         self._insert_agent('Agent/1', 'tenant', agent_id=999, deleted=True)
-        new_agents = ['Agent/1']
-        master_tenant = str(uuid.uuid4())
 
         with flush_session(self.session):
-            stat_agent_dao.insert_missing_agents(self.session, new_agents, confd_agents, master_tenant)
+            stat_agent_dao.insert_missing_agents(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
         self.assertTrue(('Agent/1', 'tenant', 1, False) in result)
@@ -112,20 +85,15 @@ class TestStatAgentDAO(DAOTestCase):
         confd_agents = {
             'Agent/1': {'id': 1, 'number': '1', 'tenant_uuid': 'tenant'},
         }
-        new_agents = ['Agent/2', 'Agent/3']
-        master_tenant = str(uuid.uuid4())
-        self._insert_agent('Agent/3', 'tenant', deleted=True)
+        self._insert_agent('Agent/2', 'tenant', deleted=True)
 
         with flush_session(self.session):
-            stat_agent_dao._create_missing_agents(
-                self.session, new_agents, confd_agents, master_tenant
-            )
+            stat_agent_dao._create_missing_agents(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
         self.assertTrue(('Agent/1', 'tenant', 1, False) in result)
-        self.assertTrue(('Agent/2', master_tenant, None, True) in result)
-        self.assertTrue(('Agent/3', 'tenant', None, True) in result)
-        self.assertEquals(len(result), 3)
+        self.assertTrue(('Agent/2', 'tenant', None, True) in result)
+        self.assertEquals(len(result), 2)
 
     def test_rename_deleted_agents_with_duplicate_name(self):
         confd_agents = {'Agent/1': {'id': 1, 'number': 'agent', 'tenant_uuid': 'tenant'}}


### PR DESCRIPTION
reason: function does not take the same arguments than
create_missing_queues