### PR TITLE
Pull request for fix-sqlalchemy-incompatibility

### DIFF
--- a/xivo_dao/alchemy/extension.py
+++ b/xivo_dao/alchemy/extension.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -78,9 +78,7 @@ class Extension(Base):
 
     outcall = association_proxy('dialpattern', 'outcall')
 
-    line_extensions = relationship('LineExtension',
-                                   cascade='all, delete-orphan',
-                                   viewonly=True)
+    line_extensions = relationship('LineExtension', viewonly=True)
 
     lines = association_proxy('line_extensions', 'line')
 

--- a/xivo_dao/alchemy/schedule.py
+++ b/xivo_dao/alchemy/schedule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2007-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -39,11 +39,7 @@ class Schedule(Base):
         cascade='all, delete-orphan',
     )
 
-    schedule_paths = relationship(
-        'SchedulePath',
-        viewonly=True,
-        cascade='all, delete-orphan',
-    )
+    schedule_paths = relationship('SchedulePath', cascade='all, delete-orphan')
 
     schedule_incalls = relationship(
         'SchedulePath',


### PR DESCRIPTION
## remove cascade for line_extension

reason: line don't need to be automatically removed by the relationship
because the API don't allow to remove extension if a line is associated

See the following commit for more information:
fc3ecf7dceae13a26b3a4aad146d03a9860cfbd8

## remove viewonly on schedule_path

reason: the schedule_paths is removed by the relationship, then we need
to keep cascade=delete
But viewonly=True is not recommended with cascade=delete

See the following commit for more information:
fc3ecf7dceae13a26b3a4aad146d03a9860cfbd8