### PR TITLE
pjsip.conf: remove the PICKUPMARK variable

### DIFF
--- a/xivo_dao/asterisk_conf_dao.py
+++ b/xivo_dao/asterisk_conf_dao.py
@@ -556,11 +556,11 @@ def find_sip_user_settings(session):
             base_config['endpoint_section_options'].append(
                 ['transport', endpoint.transport.name],
             )
-        extension = extension_mapping.get(endpoint.uuid)
-        if extension:
-            base_config['endpoint_section_options'].append(
-                ['set_var', 'PICKUPMARK={}%{}'.format(extension.exten, extension.context)]
-            )
+        # extension = extension_mapping.get(endpoint.uuid)
+        # if extension:
+        #     base_config['endpoint_section_options'].append(
+        #         ['set_var', 'PICKUPMARK={}%{}'.format(extension.exten, extension.context)]
+        #     )
         voicemails = voicemail_mapping.get(endpoint.uuid, [])
         mailboxes = []
         for voicemail in voicemails:


### PR DESCRIPTION
it messes up when using a mobile session because it tries to send the
interceptor in the Stasis app that bridges the future channels together