### PR TITLE
Pull request for check exported tables

### DIFF
--- a/xivo_dao/alchemy/all/__init__.py
+++ b/xivo_dao/alchemy/all/__init__.py
@@ -40,6 +40,7 @@ from xivo_dao.alchemy.func_key_dest_custom import FuncKeyDestCustom
 from xivo_dao.alchemy.func_key_dest_features import FuncKeyDestFeatures
 from xivo_dao.alchemy.func_key_dest_forward import FuncKeyDestForward
 from xivo_dao.alchemy.func_key_dest_group import FuncKeyDestGroup
+from xivo_dao.alchemy.func_key_dest_group_member import FuncKeyDestGroupMember
 from xivo_dao.alchemy.func_key_dest_paging import FuncKeyDestPaging
 from xivo_dao.alchemy.func_key_dest_park_position import FuncKeyDestParkPosition
 from xivo_dao.alchemy.func_key_dest_queue import FuncKeyDestQueue
@@ -60,6 +61,7 @@ from xivo_dao.alchemy.line_extension import LineExtension
 from xivo_dao.alchemy.linefeatures import LineFeatures
 from xivo_dao.alchemy.mail import Mail
 from xivo_dao.alchemy.meeting import Meeting
+from xivo_dao.alchemy.meeting import MeetingOwner
 from xivo_dao.alchemy.moh import MOH
 from xivo_dao.alchemy.monitoring import Monitoring
 from xivo_dao.alchemy.netiface import Netiface
@@ -107,6 +109,9 @@ from xivo_dao.alchemy.stats_conf import StatsConf
 from xivo_dao.alchemy.stats_conf_agent import StatsConfAgent
 from xivo_dao.alchemy.stats_conf_queue import StatsConfQueue
 from xivo_dao.alchemy.stats_conf_xivouser import StatsConfXivoUser
+from xivo_dao.alchemy.switchboard import Switchboard
+from xivo_dao.alchemy.switchboard_member_user import SwitchboardMemberUser
+from xivo_dao.alchemy.tenant import Tenant
 from xivo_dao.alchemy.trunkfeatures import TrunkFeatures
 from xivo_dao.alchemy.user_external_app import UserExternalApp
 from xivo_dao.alchemy.user_line import UserLine
@@ -156,6 +161,7 @@ __all__ = [
     "FuncKeyDestFeatures",
     "FuncKeyDestForward",
     "FuncKeyDestGroup",
+    "FuncKeyDestGroupMember",
     "FuncKeyDestPaging",
     "FuncKeyDestParkPosition",
     "FuncKeyDestQueue",
@@ -176,6 +182,7 @@ __all__ = [
     "LineFeatures",
     "Mail",
     "Meeting",
+    "MeetingOwner",
     "MOH",
     "Monitoring",
     "Netiface",
@@ -184,7 +191,6 @@ __all__ = [
     "Paging",
     "PagingUser",
     "ParkingLot",
-    "PhoneFunckey",
     "Pickup",
     "PickupMember",
     "PJSIPTransport",
@@ -224,6 +230,9 @@ __all__ = [
     "StatsConfAgent",
     "StatsConfQueue",
     "StatsConfXivoUser",
+    "Switchboard",
+    "SwitchboardMemberUser",
+    "Tenant",
     "TrunkFeatures",
     "UserExternalApp",
     "UserLine",

--- a/xivo_dao/alchemy/all/tests/test_all.py
+++ b/xivo_dao/alchemy/all/tests/test_all.py
@@ -1,0 +1,53 @@
+# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+import importlib
+import inspect
+import pkgutil
+import xivo_dao.alchemy
+import xivo_dao.alchemy.all
+
+from xivo_dao.helpers.db_manager import Base
+
+
+def list_exported_classes():
+    for exported_class in sorted(xivo_dao.alchemy.all.__all__):
+        yield exported_class
+
+
+def explore_alchemy():
+    for sub_module in pkgutil.walk_packages(
+        xivo_dao.alchemy.__path__, prefix='xivo_dao.alchemy.'
+    ):
+        _, sub_module_name, _ = sub_module
+
+        if '.tests.' in sub_module_name:
+            continue
+
+        yield sub_module_name
+
+
+def list_model_names():
+    for submodule_name in explore_alchemy():
+        submodule = importlib.import_module(submodule_name)
+
+        for element_name in dir(submodule):
+            element = getattr(submodule, element_name)
+            if not inspect.isclass(element):
+                continue
+            if not issubclass(element, Base):
+                continue
+            if element_name == 'Base':
+                continue
+
+            # Exclude polymorphic classes that are not real tables
+            if ('polymorphic_identity' in getattr(element, '__mapper_args__', {})
+                    and 'polymorphic_on' not in getattr(element, '__mapper_args__', {})):
+                continue
+
+            yield element_name
+
+
+def test_all_classes_exported():
+    assert set(list_model_names()) == set(list_exported_classes())


### PR DESCRIPTION
## zuul: check all tables are listed for creation

Why:

* It is easy to forget listing a new table in the `all` module
* It can take a while to debug the subsequent errors, so it's better to
check early

## alchemy: fix missing exported classes

Why:

* The new Zuul script is flagging those classes
* They have no good reason to not be exported