### PR TITLE
WAZO-2185: Fix DAO and migration script diff

### DIFF
--- a/xivo_dao/alchemy/endpoint_sip_options_view.py
+++ b/xivo_dao/alchemy/endpoint_sip_options_view.py
@@ -22,7 +22,7 @@ def _generate_selectable():
         ]
     ).cte(recursive=True)
 
-    endpoints = cte.union(
+    endpoints = cte.union_all(
         select(
             [
                 EndpointSIPTemplate.parent_uuid.label('uuid'),


### PR DESCRIPTION
Why:

* Alembic script and DAO tables were not the same for endpoint_sip_options_view,
causing tests to fail.

This change addresses the need by:

* Changing union to union_all in endpoint_sip_options_view recursive query