### PR TITLE
WAZO-2185: Add table to .select_from string

### DIFF
--- a/xivo_dao/alchemy/endpoint_sip.py
+++ b/xivo_dao/alchemy/endpoint_sip.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from sqlalchemy import and_, text, select, column
+from sqlalchemy import and_, text, select, column, table
 from sqlalchemy.orm import column_property, relationship
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -84,7 +84,7 @@ class EndpointSIP(Base):
     _options = column_property(
         select([column('options')])
         .where(column('root') == uuid)
-        .select_from('endpoint_sip_options_view')
+        .select_from(table('endpoint_sip_options_view'))
     )
     _aor_section = relationship(
         'AORSection',

--- a/xivo_dao/helpers/db_views.py
+++ b/xivo_dao/helpers/db_views.py
@@ -6,7 +6,7 @@ import six
 
 from sqlalchemy import Column, MetaData, PrimaryKeyConstraint, Table, Index
 from sqlalchemy.ext import compiler
-from sqlalchemy.ext.declarative.api import DeclarativeMeta
+from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.event import listens_for, listen, contains
 from sqlalchemy.exc import InvalidRequestError, NoInspectionAvailable
 from sqlalchemy.inspection import inspect


### PR DESCRIPTION
Why:

* With recent version of SQLAlchemy (i.e 1.4), passing a string to select_from
without specifying it's type is flagged as an error, because it doesn't
know what to resolve it to.

* Fix wazo-agentd integration tests failing