### PR TITLE
WAZO-2185: fix matview sqlalchemy compatibility

### DIFF
--- a/xivo_dao/alchemy/endpoint_sip.py
+++ b/xivo_dao/alchemy/endpoint_sip.py
@@ -85,6 +85,7 @@ class EndpointSIP(Base):
         select([column('options')])
         .where(column('root') == uuid)
         .select_from(table('endpoint_sip_options_view'))
+        .as_scalar()
     )
     _aor_section = relationship(
         'AORSection',

--- a/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
@@ -20,6 +20,7 @@ class TestView(DAOTestCase):
         assert_that(sip.get_option_value('key'), equal_to(None))
 
         EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        self.session.expire(sip)
 
         assert_that(sip.get_option_value('key'), equal_to('value'))
 


### PR DESCRIPTION
This PR fixes the implementation of MaterializedView so that it is also compatible with SQLAlchemy >= 1.4

Some integration tests don't pin python package versions hence in this case, when run under SQLAlchemy 1.4.X,
wazo-agentd integration test fails.  

Instead of trying to pin every package in all repos, this fix modifies MaterializedView to be compatible
with SQLAlchemy 1.2 and greater (1.4.27 tested here)