### PR TITLE
tests: remove deprecation warnings from tests

### DIFF
--- a/xivo_dao/tests/test_stat_agent_dao.py
+++ b/xivo_dao/tests/test_stat_agent_dao.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import assert_that, contains_inanyorder
 
 from xivo_dao import stat_agent_dao
 from xivo_dao.alchemy.stat_agent import StatAgent
@@ -40,10 +42,11 @@ class TestStatAgentDAO(DAOTestCase):
             stat_agent_dao.insert_missing_agents(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
-        self.assertTrue(('Agent/1', 'tenant1', 1, False) in result)
-        self.assertTrue(('Agent/2', 'tenant2', 2, False) in result)
-        self.assertTrue(('Agent/3', 'tenant3', 3, True) in result)
-        self.assertEquals(len(result), 3)
+        assert_that(result, contains_inanyorder(
+            ('Agent/1', 'tenant1', 1, False),
+            ('Agent/2', 'tenant2', 2, False),
+            ('Agent/3', 'tenant3', 3, True),
+        ))
 
     def test_when_agent_marked_as_deleted_then_new_one_is_created(self):
         confd_agents = [{'id': 1, 'number': '1', 'tenant_uuid': 'tenant'}]
@@ -53,9 +56,10 @@ class TestStatAgentDAO(DAOTestCase):
             stat_agent_dao.insert_missing_agents(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
-        self.assertTrue(('Agent/1', 'tenant', 1, False) in result)
-        self.assertTrue(('Agent/1_', 'tenant', 999, True) in result)
-        self.assertEquals(len(result), 2)
+        assert_that(result, contains_inanyorder(
+            ('Agent/1', 'tenant', 1, False),
+            ('Agent/1_', 'tenant', 999, True),
+        ))
 
     def test_mark_recreated_agents_with_same_number_as_deleted(self):
         confd_agents = {'Agent/1': {'id': 1, 'number': '1', 'tenant_uuid': 'tenant'}}
@@ -65,8 +69,9 @@ class TestStatAgentDAO(DAOTestCase):
             stat_agent_dao._mark_recreated_agents_with_same_number_as_deleted(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
-        self.assertTrue(('Agent/1', 'tenant', 999, True) in result)
-        self.assertEquals(len(result), 1)
+        assert_that(result, contains_inanyorder(
+            ('Agent/1', 'tenant', 999, True)
+        ))
 
     def test_mark_non_confd_agents_as_deleted(self):
         confd_agents = [{'id': 1, 'number': '1', 'tenant_uuid': 'tenant'}]
@@ -77,9 +82,10 @@ class TestStatAgentDAO(DAOTestCase):
             stat_agent_dao._mark_non_confd_agents_as_deleted(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
-        self.assertTrue(('Agent/2', 'tenant', 2, True) in result)
-        self.assertTrue(('Agent/3', 'tenant', None, True) in result)
-        self.assertEquals(len(result), 2)
+        assert_that(result, contains_inanyorder(
+            ('Agent/2', 'tenant', 2, True),
+            ('Agent/3', 'tenant', None, True),
+        ))
 
     def test_create_missing_agents(self):
         confd_agents = {
@@ -91,9 +97,10 @@ class TestStatAgentDAO(DAOTestCase):
             stat_agent_dao._create_missing_agents(self.session, confd_agents)
 
         result = self._fetch_stat_agents()
-        self.assertTrue(('Agent/1', 'tenant', 1, False) in result)
-        self.assertTrue(('Agent/2', 'tenant', None, True) in result)
-        self.assertEquals(len(result), 2)
+        assert_that(result, contains_inanyorder(
+            ('Agent/1', 'tenant', 1, False),
+            ('Agent/2', 'tenant', None, True),
+        ))
 
     def test_rename_deleted_agents_with_duplicate_name(self):
         confd_agents = {'Agent/1': {'id': 1, 'number': 'agent', 'tenant_uuid': 'tenant'}}
@@ -106,9 +113,10 @@ class TestStatAgentDAO(DAOTestCase):
             )
 
         result = self._fetch_stat_agents()
-        self.assertTrue(('Agent/1_', 'tenant', 1, True) in result)
-        self.assertTrue(('Agent/1__', 'tenant', 1, True) in result)
-        self.assertEquals(len(result), 2)
+        assert_that(result, contains_inanyorder(
+            ('Agent/1_', 'tenant', 1, True),
+            ('Agent/1__', 'tenant', 1, True),
+        ))
 
     def _fetch_stat_agents(self):
         return [

--- a/xivo_dao/tests/test_stat_queue_dao.py
+++ b/xivo_dao/tests/test_stat_queue_dao.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
+
+from hamcrest import assert_that, contains_inanyorder
 
 from xivo_dao import stat_queue_dao
 from xivo_dao.alchemy.stat_queue import StatQueue
@@ -61,14 +63,15 @@ class TestStatQueueDAO(DAOTestCase):
             stat_queue_dao.insert_if_missing(self.session, new_queues, confd_queues, master_tenant)
 
         result = self._fetch_stat_queues()
-        self.assertTrue(('queue1', 'tenant1', 1, False) in result)
-        self.assertTrue(('queue2', 'tenant2', 2, False) in result)
-        self.assertTrue(('queue3', 'tenant3', 3, False) in result)
-        self.assertTrue(('queue4', 'tenant4', 4, False) in result)
-        self.assertTrue(('queue5', master_tenant, None, True) in result)
-        self.assertTrue(('queue6', 'tenant6', 6, True) in result)
-        self.assertTrue(('queue7', 'tenant7', 7, True) in result)
-        self.assertEquals(len(result), 7)
+        assert_that(result, contains_inanyorder(
+            ('queue1', 'tenant1', 1, False),
+            ('queue2', 'tenant2', 2, False),
+            ('queue3', 'tenant3', 3, False),
+            ('queue4', 'tenant4', 4, False),
+            ('queue5', master_tenant, None, True),
+            ('queue6', 'tenant6', 6, True),
+            ('queue7', 'tenant7', 7, True),
+        ))
 
     def test_when_queue_marked_as_deleted_then_new_one_is_created(self):
         confd_queues = [{'id': 1, 'name': 'queue', 'tenant_uuid': 'tenant'}]
@@ -80,9 +83,10 @@ class TestStatQueueDAO(DAOTestCase):
             stat_queue_dao.insert_if_missing(self.session, new_queues, confd_queues, master_tenant)
 
         result = self._fetch_stat_queues()
-        self.assertTrue(('queue', 'tenant', 1, False) in result)
-        self.assertTrue(('queue_', 'tenant', 999, True) in result)
-        self.assertEquals(len(result), 2)
+        assert_that(result, contains_inanyorder(
+            ('queue', 'tenant', 1, False),
+            ('queue_', 'tenant', 999, True),
+        ))
 
     def test_mark_recreated_queues_with_same_name_as_deleted(self):
         confd_queues = {'queue': {'id': 1, 'name': 'queue', 'tenant_uuid': 'tenant'}}
@@ -92,8 +96,9 @@ class TestStatQueueDAO(DAOTestCase):
             stat_queue_dao._mark_recreated_queues_with_same_name_as_deleted(self.session, confd_queues)
 
         result = self._fetch_stat_queues()
-        self.assertTrue(('queue', 'tenant', 999, True) in result)
-        self.assertEquals(len(result), 1)
+        assert_that(result, contains_inanyorder(
+            ('queue', 'tenant', 999, True),
+        ))
 
     def test_mark_non_confd_queues_as_deleted(self):
         confd_queues = [{'id': 1, 'name': 'queue1', 'tenant_uuid': 'tenant'}]
@@ -104,9 +109,10 @@ class TestStatQueueDAO(DAOTestCase):
             stat_queue_dao._mark_non_confd_queues_as_deleted(self.session, confd_queues)
 
         result = self._fetch_stat_queues()
-        self.assertTrue(('queue2', 'tenant', 2, True) in result)
-        self.assertTrue(('queue3', 'tenant', None, True) in result)
-        self.assertEquals(len(result), 2)
+        assert_that(result, contains_inanyorder(
+            ('queue2', 'tenant', 2, True),
+            ('queue3', 'tenant', None, True),
+        ))
 
     def test_create_missing_queues(self):
         confd_queues = {
@@ -122,10 +128,11 @@ class TestStatQueueDAO(DAOTestCase):
             )
 
         result = self._fetch_stat_queues()
-        self.assertTrue(('queue1', 'tenant', 1, False) in result)
-        self.assertTrue(('queue2', master_tenant, None, True) in result)
-        self.assertTrue(('queue3', 'tenant', None, True) in result)
-        self.assertEquals(len(result), 3)
+        assert_that(result, contains_inanyorder(
+            ('queue1', 'tenant', 1, False),
+            ('queue2', master_tenant, None, True),
+            ('queue3', 'tenant', None, True),
+        ))
 
     def test_rename_deleted_queues_with_duplicate_name(self):
         confd_queues = {'queue': {'id': 1, 'name': 'queue', 'tenant_uuid': 'tenant'}}
@@ -138,9 +145,10 @@ class TestStatQueueDAO(DAOTestCase):
             )
 
         result = self._fetch_stat_queues()
-        self.assertTrue(('queue_', 'tenant', 1, True) in result)
-        self.assertTrue(('queue__', 'tenant', 1, True) in result)
-        self.assertEquals(len(result), 2)
+        assert_that(result, contains_inanyorder(
+            ('queue_', 'tenant', 1, True),
+            ('queue__', 'tenant', 1, True),
+        ))
 
     def test_clean_table(self):
         self._insert_queue('queue1')


### PR DESCRIPTION
assertEquals is deprecated assertEqual should be used instead. I used hamcrest
and contains_inanyorder to remove the length assertion completely