### PR TITLE
meeting: set the tz when inserting the meeting date

### DIFF
--- a/xivo_dao/alchemy/meeting.py
+++ b/xivo_dao/alchemy/meeting.py
@@ -2,8 +2,6 @@
 # Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import datetime
-
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -20,7 +18,13 @@ from xivo_dao.helpers.db_manager import Base
 
 
 def utcnow_with_tzinfo():
-    return datetime.datetime.now(datetime.timezone.utc)
+    from datetime import datetime
+    try:
+        from datetime import timezone
+        return datetime.now(timezone.utc)
+    except ImportError:
+        # NOTE: Python2 this is unused anyway
+        return datetime.now()
 
 
 class MeetingOwner(Base):

--- a/xivo_dao/alchemy/meeting.py
+++ b/xivo_dao/alchemy/meeting.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -17,6 +17,10 @@ from sqlalchemy.types import (
     Text
 )
 from xivo_dao.helpers.db_manager import Base
+
+
+def utcnow_with_tzinfo():
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 class MeetingOwner(Base):
@@ -48,7 +52,7 @@ class Meeting(Base):
     name = Column(Text)
     guest_endpoint_sip_uuid = Column(UUID(as_uuid=True), ForeignKey('endpoint_sip.uuid', ondelete='SET NULL'))
     tenant_uuid = Column(String(36), ForeignKey('tenant.uuid', ondelete='CASCADE'), nullable=False)
-    created_at = Column(DateTime(timezone=True), default=datetime.datetime.utcnow, server_default=text("(now() at time zone 'utc')"))
+    created_at = Column(DateTime(timezone=True), default=utcnow_with_tzinfo, server_default=text("(now() at time zone 'utc')"))
     persistent = Column(Boolean, server_default='false', nullable=False)
     number = Column(Text, nullable=False)
 


### PR DESCRIPTION
utcnow() returns the time without the timezone. when inserting the value into a
datetime field with tz the tz is going to be the tz of the stack when
unspecified.  Adding the tz to the now time explicitly removes the ambiguity and
forces postgres to store the right time. Which is going to be the localized time
with the appropriate offset.