### PR TITLE
Fix mobile ring group issue

### DIFF
--- a/xivo_dao/resources/func_key/hint_dao.py
+++ b/xivo_dao/resources/func_key/hint_dao.py
@@ -99,7 +99,7 @@ def user_shared_hints(session):
     query = session.query(UserFeatures).options(joinedload('user_lines').joinedload('line'))
     hints = []
     for user in query.all():
-        ifaces = []
+        ifaces = ['Custom:{}'.format(user.uuid)]
         for line in user.lines:
             if line.endpoint_custom_id:
                 ifaces.append(line.name)


### PR DESCRIPTION
If you add mobile user in a group, because in mobile environnement there is no AOR, group (queue) don't send any call to the endpoint. More information on the ticket.