### PR TITLE
Pull request for fix-search-issue-with-moh-uuid

### DIFF
--- a/xivo_dao/resources/parking_lot/search.py
+++ b/xivo_dao/resources/parking_lot/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.parking_lot import ParkingLot
@@ -15,9 +15,16 @@ config = SearchConfig(
         'slots_start': ParkingLot.slots_start,
         'slots_end': ParkingLot.slots_end,
         'timeout': ParkingLot.timeout,
-        'music_on_hold': ParkingLot.music_on_hold,
         'exten': ParkingLot.exten,
     },
+    search=[
+        'id',
+        'name',
+        'slots_start',
+        'slots_end',
+        'timeout',
+        'exten',
+    ],
     default_sort='name',
 )
 

--- a/xivo_dao/resources/parking_lot/search.py
+++ b/xivo_dao/resources/parking_lot/search.py
@@ -18,7 +18,6 @@ config = SearchConfig(
         'exten': ParkingLot.exten,
     },
     search=[
-        'id',
         'name',
         'slots_start',
         'slots_end',

--- a/xivo_dao/resources/user/search.py
+++ b/xivo_dao/resources/user/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import six
@@ -43,7 +43,6 @@ config = SearchConfig(table=UserFeatures,
                               'userfield',
                               'email',
                               'mobile_phone_number',
-                              'music_on_hold',
                               'preprocess_subroutine',
                               'outgoing_caller_id',
                               'exten',


### PR DESCRIPTION
## do not search on music_on_hold field

why: since 21.15, the moh name is built with tenant slug and UUID, which
doesn't make sense to match this field on global search

## parking lot: do not search on id field

why: it doesn't make sense to include id in a global search
If you need specific ID, you could use "id" query string instead of
"search"