### PR TITLE
user line: keep group/queue member if secondary line deleted

### DIFF
--- a/xivo_dao/resources/user_line/tests/test_dao.py
+++ b/xivo_dao/resources/user_line/tests/test_dao.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2013-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -213,7 +213,11 @@ class TestAssociateUserLine(DAOTestCase):
 class TestDissociateUserLine(DAOTestCase):
 
     def test_dissociate_user_line_with_queue_member(self):
-        user_line = self.add_user_line_with_queue_member()
+        sip = self.add_endpoint_sip()
+        user_line = self.add_user_line_with_queue_member(
+            name_line=sip.name,
+            endpoint_sip_uuid=sip.uuid,
+        )
 
         user_line_dao.dissociate(user_line.user, user_line.line)
 
@@ -413,9 +417,14 @@ class TestAssociateAllLines(DAOTestCase):
         ))
 
     def test_dissociate_then_fixes_are_executed(self):
+        sip = self.add_endpoint_sip()
         user = self.add_user()
-        line = self.add_line()
-        self.add_queue_member(userid=user.id, usertype='user')
+        line = self.add_line(name=sip.name, endpoint_sip_uuid=sip.uuid)
+        self.add_queue_member(
+            userid=user.id,
+            usertype='user',
+            interface='PJSIP/{}'.format(sip.name),
+        )
         self.add_user_line(line_id=line.id, user_id=user.id)
 
         user_line_dao.associate_all_lines(user, [])

--- a/xivo_dao/tests/test_dao.py
+++ b/xivo_dao/tests/test_dao.py
@@ -208,6 +208,7 @@ class ItemInserter(object):
         kwargs.setdefault('mobilephonenumber', '')
         kwargs.setdefault('description', '')
         kwargs.setdefault('userfield', '')
+        kwargs.setdefault('endpoint_sip_uuid', None)
 
         user = self.add_user(firstname=kwargs['firstname'],
                              lastname=kwargs['lastname'],
@@ -221,9 +222,11 @@ class ItemInserter(object):
         line = self.add_line(context=kwargs['context'],
                              name=kwargs['name_line'],
                              device=kwargs['device'],
-                             commented=kwargs['commented_line'])
+                             commented=kwargs['commented_line'],
+                             endpoint_sip_uuid=kwargs['endpoint_sip_uuid'])
         self.add_queue_member(userid=user.id,
-                              usertype='user')
+                              usertype='user',
+                              interface='PJSIP/{}'.format(line.name))
         user_line = self.add_user_line(line_id=line.id,
                                        user_id=user.id)
 


### PR DESCRIPTION
When a user is a member of a group or a queue the user's main line is the member.
Not any other lines. When deleting a line, only the primary line should trigger a removal from the group or queue.

Extensions group members and agent queue members do not fall into this fix