### PR TITLE
debian: add conflict with xivo-libdao

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,9 @@ X-Python3-Version: >= 3.7
 
 Package: xivo-libdao-python3
 Architecture: all
+Provides: xivo-libdao
+Conflicts: xivo-libdao
+Replaces: xivo-libdao
 Depends: ${python3:Depends},
          ${misc:Depends},
          xivo-lib-python-python3,


### PR DESCRIPTION
why: xivo-libdao provided the /etc/xivo-dao/config.yml which now is
provided by xivo-libdao-python3. Since we mix lib and config package, we
must add this ugly workaround.
A better solution would be to remove config file from this lib. But it's
out of scope for now