### PR TITLE
WP-780: use `selectin` eagerloading strategy

### DIFF
--- a/xivo_dao/alchemy/rightcall.py
+++ b/xivo_dao/alchemy/rightcall.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -58,6 +58,7 @@ class RightCall(Base):
         )""",
         foreign_keys='RightCallMember.rightcallid',
         viewonly=True,
+        lazy='selectin',
     )
     groups = association_proxy('rightcall_groups', 'group')
 
@@ -69,6 +70,7 @@ class RightCall(Base):
         )""",
         foreign_keys='RightCallMember.rightcallid',
         viewonly=True,
+        lazy='selectin',
     )
     users = association_proxy('rightcall_users', 'user')
 

--- a/xivo_dao/alchemy/rightcallmember.py
+++ b/xivo_dao/alchemy/rightcallmember.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -28,6 +28,7 @@ class RightCallMember(Base):
                          primaryjoin="""and_(RightCallMember.type == 'group',
                                              RightCallMember.typeval == cast(GroupFeatures.id, String))""",
                          foreign_keys='RightCallMember.typeval',
+                         lazy='selectin',
                          viewonly=True)
 
     outcall = relationship('Outcall',
@@ -40,6 +41,7 @@ class RightCallMember(Base):
                         primaryjoin="""and_(RightCallMember.type == 'user',
                                             RightCallMember.typeval == cast(UserFeatures.id, String))""",
                         foreign_keys='RightCallMember.typeval',
+                        lazy='selectin',
                         viewonly=True)
 
     rightcall = relationship('RightCall',


### PR DESCRIPTION
Why:

* Users were not loaded automatically with RightCallMembers, meaning there was a fetch for each user.

During testing, eagerloading the users accelerates the query from ~10 sec down to <= 1 sec

Method to test:
1. use a stack with lots of users in a call permission
2. use console to calculate query time for `/api/confd/1.1/callpermissions?recurse=true`
3. apply patch from this commit
4. use console to calculate query time for `/api/confd/1.1/callpermissions?recurse=true`
