### PR TITLE
Add Exception as parent to FormattedError

### DIFF
--- a/xivo_dao/helpers/errors.py
+++ b/xivo_dao/helpers/errors.py
@@ -25,7 +25,7 @@ def _format_list(elements):
     return ', '.join(elements)
 
 
-class FormattedError:
+class FormattedError(Exception):
 
     def __init__(self, exception, error_template):
         self.exception = exception


### PR DESCRIPTION
Python 3 enforces that all exceptions be derived from 'BaseException' which is the root of 'Exception' hierarchy. Although this practice isn’t new, it was never enforced.

All the exceptions to be used with 'except' should inherit from Exception class. 'BaseException' to be used as base class only for exceptions that should be handled at top-level like 'SystemExit' or 'KeyboardInterrupt'.