### PR TITLE
WAZO-3255: use SQLAlchemy-utils

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Depends: ${python3:Depends},
          ${misc:Depends},
          xivo-lib-python-python3,
          python3-sqlalchemy,
+         python3-sqlalchemy-utils,
          python3-unidecode
 Description: Wazo telephony systems library for directories manager
  Wazo is a system based on a powerful IPBX, to bring an easy to

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 psycopg2-binary==2.8.6
 pyyaml==5.3.1
 sqlalchemy==1.3.22
+sqlalchemy_utils==0.36.8
 unidecode==1.2.0

--- a/xivo_dao/alchemy/endpoint_sip_options_view.py
+++ b/xivo_dao/alchemy/endpoint_sip_options_view.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import select, join, cast, literal, func, String, Index, text
@@ -82,10 +82,9 @@ def _generate_selectable():
 
 
 class EndpointSIPOptionsView(MaterializedView):
-    __view__ = create_materialized_view(
+    __table__ = create_materialized_view(
         'endpoint_sip_options_view',
         _generate_selectable(),
-        dependencies=[EndpointSIPSectionOption],
         indexes=[
             Index('endpoint_sip_options_view__idx_root', text('root'), unique=True),
         ],

--- a/xivo_dao/alchemy/tests/test_endpoint_sip.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -362,7 +362,7 @@ class TestOptionValue(DAOTestCase):
         super().setUp()
         self.sip = self.add_endpoint_sip()
         self.sip.endpoint_section_options = [('test', 'value')]
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
     def test_get_value(self):
         assert_that(
@@ -378,7 +378,7 @@ class TestOptionValue(DAOTestCase):
 
     def test_get_value_no_option_values(self):
         sip = self.add_endpoint_sip()
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         assert_that(
             sip.get_option_value('somevalue'),
@@ -393,7 +393,7 @@ class TestCallerId(DAOTestCase):
         sip = self.add_endpoint_sip(
             templates=[template1, template2], caller_id='template3'
         )
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template3'))
@@ -402,7 +402,7 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(caller_id='template1')
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template1'))
@@ -412,7 +412,7 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(templates=[template0])
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template0'))
@@ -420,7 +420,7 @@ class TestCallerId(DAOTestCase):
     def test_callerid_inheritance(self):
         template1 = self.add_endpoint_sip(caller_id='template1')
         sip = self.add_endpoint_sip(templates=[template1])
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         assert_that(
             sip.get_option_value('callerid'),

--- a/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -18,7 +18,7 @@ class TestView(DAOTestCase):
 
         assert_that(sip.get_option_value('key'), equal_to(None))
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
         self.session.expire(sip)
 
         assert_that(sip.get_option_value('key'), equal_to('value'))
@@ -34,7 +34,7 @@ class TestView(DAOTestCase):
         template3.endpoint_section_options = [('templ3', 'third')]
         sip.endpoint_section_options = [('sip', 'fourth')]
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         assert_that(
             sip._options,
@@ -48,7 +48,7 @@ class TestView(DAOTestCase):
         template.endpoint_section_options = [('option', 'template')]
         sip.endpoint_section_options = [('option', 'sip')]
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         assert_that(sip.get_option_value('option'), equal_to('sip'))
 
@@ -59,7 +59,7 @@ class TestView(DAOTestCase):
         template.endpoint_section_options = [('second', 'value2')]
         sip.endpoint_section_options = [('first', 'value1')]
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        EndpointSIPOptionsView.refresh()
 
         result = (
             self.session.query(EndpointSIPOptionsView).filter_by(root=sip.uuid).first()

--- a/xivo_dao/helpers/db_views.py
+++ b/xivo_dao/helpers/db_views.py
@@ -1,192 +1,39 @@
 # Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import Column, MetaData, PrimaryKeyConstraint, Table, Index
-from sqlalchemy.ext import compiler
-from sqlalchemy.ext.declarative import DeclarativeMeta
-from sqlalchemy.event import listens_for, listen, contains
-from sqlalchemy.exc import InvalidRequestError, NoInspectionAvailable
-from sqlalchemy.inspection import inspect
-from sqlalchemy.sql.ddl import DDLElement
-from sqlalchemy.sql.selectable import Selectable
+from sqlalchemy import Index
+from sqlalchemy.sql import Selectable
+from sqlalchemy_utils import view
 
-from .db_manager import Base, Session, daosession
+from .db_manager import Base, Session
 
 
-# Adapted from:
-# * https://github.com/jeffwidman/sqlalchemy-postgresql-materialized-views
-# * https://github.com/kvesteri/sqlalchemy-utils
-#
-# Notes:
-# * SQLAlchemy-utils package provides utilities for database views
-#   Until wazo-platform runs on Debian Bullseye, we cannot use recent
-#   enough packaged sqlalchemy-utils (>= 0.33.6, buster is 0.32.21) which
-#   implements the view functions below
-
-
-# Todo: Replace by SQLAlchemy-Utils when possible
-class CreateView(DDLElement):
-    def __init__(self, name, selectable, materialized):
-        self.name = name
-        self.selectable = selectable
-        self.materialized = materialized
-
-
-@compiler.compiles(CreateView)
-def _compile_create_view(element, compiler, **kw):
-    name = compiler.dialect.identifier_preparer.quote(element.name)
-    selectable = compiler.sql_compiler.process(element.selectable, literal_binds=True)
-    materialized = 'MATERIALIZED ' if element.materialized else ''
-
-    return f'CREATE {materialized}VIEW {name} AS {selectable}'
-
-
-# Todo: Replace by SQLAlchemy-Utils when possible
-class DropView(DDLElement):
-    def __init__(self, name, materialized, cascade=True):
-        self.name = name
-        self.materialized = materialized
-        self.cascade = cascade
-
-
-@compiler.compiles(DropView)
-def _compile_drop_view(element, compiler, **kw):
-    name = compiler.dialect.identifier_preparer.quote(element.name)
-    materialized = 'MATERIALIZED ' if element.materialized else ''
-    cascade = 'CASCADE ' if element.cascade else ''
-
-    return f'DROP {materialized}VIEW IF EXISTS {name} {cascade}'
-
-
-# Replace by SQLAlchemy-Utils when possible
-def _create_table_from_selectable(name, selectable, indexes=None, **kwargs):
-    indexes = indexes or []
-    metadata = MetaData()
-
-    try:
-        columns = selectable.selected_columns  # SQLAlchemy >= 1.4
-    except AttributeError:
-        columns = selectable.columns  # SQLAlchemy 1.2 compat
-
-    cols = indexes
-    for col in columns:
-        cols.append(Column(col.name, col.type, primary_key=col.primary_key))
-
-    table = Table(name, metadata, *cols)
-    if not any([col.primary_key for col in columns]):
-        table.append_constraint(PrimaryKeyConstraint(*[col.name for col in columns]))
-
-    return table
-
-
-# Todo: Replace by SQLAlchemy-Utils when possible
-def _create_materialized_view(name, selectable, metadata, indexes=None, **kwargs):
-    table = _create_table_from_selectable(name, selectable, indexes=indexes)
-
-    listen(metadata, 'after_create', CreateView(name, selectable, True))
-    listen(metadata, 'before_drop', DropView(name, True))
-
-    @listens_for(metadata, 'after_create')
-    def create_indexes(target, connection, **kw):
-        for idx in table.indexes:
-            idx.create(connection)
-
-    return table
-
-
-# Todo: Replace by SQLAlchemy-Utils when possible
-def _refresh_materialized_view(session, name, concurrently):
-    view_name = session.bind.engine.dialect.identifier_preparer.quote(name)
-    concurrently = 'CONCURRENTLY ' if concurrently else ''
-
-    session.flush()
-    session.execute(f'REFRESH MATERIALIZED VIEW {concurrently}{view_name}')
-
-
-def create_materialized_view(name, selectable, dependencies=None, indexes=None):
+def create_materialized_view(
+    name: str, selectable: Selectable, indexes: list[Index] = None
+):
     """
     Create a materialized view
 
-    :param name: The name of the view to create.
-    :param selectable: An SQLAlchemy selectable e.g. a select() statement.
-    :param dependencies:
-        An optional list of models to depend on.  Modifying, adding or removing
-        an instance of these models in the database will trigger the view to update itself.
-    :param indexes: An optional list of SQLAlchemy Index instances.
-
+    :param name (str): The name of the view to create.
+    :param selectable (Selectable): An SQLAlchemy selectable e.g. a select() statement.
+    :param indexes (list[Index]): An optional list of SQLAlchemy Index instances.
     """
-    dependencies = dependencies or []
-    indexes = indexes or []
 
     if not name:
-        raise ValueError('View must have a name')
+        raise ValueError('view must have a name')
 
     if not isinstance(selectable, Selectable):
-        raise ValueError("Invalid View selectable, must be an SQLAlchemy Selectable.")
+        raise ValueError('invalid view selectable, must be an SQLAlchemy Selectable')
 
-    for dependency in dependencies:
-        try:
-            inspect(dependency.__mapper__)
-        except (NoInspectionAvailable, AttributeError):
-            raise ValueError(
-                'Invalid view dependency, must be an SQLAlchemy mapped class'
-            )
+    if indexes:
+        for index in indexes:
+            if not isinstance(index, Index):
+                raise ValueError('invalid view index, must be an SQLAlchemy index')
 
-    for index in indexes:
-        if not isinstance(index, Index):
-            raise ValueError('Invalid view index, must be an SQLAlchemy index')
-
-    table = _create_materialized_view(name, selectable, Base.metadata, indexes)
-    return table, dependencies
+    return view.create_materialized_view(name, selectable, Base.metadata, indexes)
 
 
-class _MaterializedViewMeta(DeclarativeMeta):
-    def __init__(self, clsname, bases, attrs):
-        for cls_ in bases:
-            if cls_.__name__ == 'MaterializedView' and not hasattr(self, '__view__'):
-                raise InvalidRequestError(
-                    f"Class '{self}' must specify a '__view__' attribute"
-                )
-        try:
-            self.__table__, self._view_dependencies = getattr(self, '__view__')
-            attrs['__table__'] = self.__table__
-        except AttributeError:
-            pass
-        except (TypeError, ValueError):
-            raise InvalidRequestError(
-                "__view__ is invalid, use 'create_materialized_view' helper function"
-            )
-        super().__init__(clsname, bases, attrs)
-        self._view_dependencies_handler = None
-        self._track_dependencies()
-
-    @daosession
-    def refresh(session, self, concurrently=True):
-        _refresh_materialized_view(session, self.__table__.fullname, concurrently)
-
-    def _track_dependencies(self):
-        if not hasattr(self, '_view_dependencies'):
-            return
-        targets = self._view_dependencies
-        if targets:
-
-            @listens_for(Session, 'before_commit')
-            def _before_session_commit_handler(session):
-                for obj in session:
-                    if isinstance(obj, tuple(targets)):
-                        self.refresh(concurrently=True)
-                        return
-
-            self._view_dependencies_handler = staticmethod(
-                _before_session_commit_handler
-            )
-
-    @property
-    def autorefresh(self):
-        return contains(Session, 'before_commit', self._view_dependencies_handler)
-
-
-class MaterializedView(Base, metaclass=_MaterializedViewMeta):
+class MaterializedView(Base):
     """
     Materialized View base class
 
@@ -194,7 +41,11 @@ class MaterializedView(Base, metaclass=_MaterializedViewMeta):
 
     Usage:
 
-    Assign the '__view__' attribute using the create_materialized_view function
+        * Assign the `__table__` attribute using the `create_materialized_view` helper function
     """
 
-    __abstract__ = True
+    __abstract__: bool = True
+
+    @classmethod
+    def refresh(cls, concurrently: bool = True) -> None:
+        view.refresh_materialized_view(Session(), cls.__table__.fullname, concurrently)

--- a/xivo_dao/helpers/tests/test_materialized_view.py
+++ b/xivo_dao/helpers/tests/test_materialized_view.py
@@ -1,6 +1,7 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from functools import partial
 from hamcrest import (
     assert_that,
     instance_of,
@@ -8,9 +9,8 @@ from hamcrest import (
     not_,
     raises,
     equal_to,
-    has_items,
 )
-from sqlalchemy import select, Table, Column, Integer
+from sqlalchemy import select, Table
 from sqlalchemy.exc import InvalidRequestError
 
 from xivo_dao.tests.test_dao import DAOTestCase
@@ -21,8 +21,7 @@ from xivo_dao.helpers.db_views import MaterializedView, create_materialized_view
 class TestCreateMaterializedView(DAOTestCase):
     def test_create_materialized_view(self):
         result = create_materialized_view('test', select([1]))
-        assert_that(result, instance_of(tuple))
-        assert_that(result, has_items(instance_of(Table), instance_of(list)))
+        assert_that(result, instance_of(Table))
 
     def test_create_materialized_view_with_no_name(self):
         assert_that(
@@ -42,14 +41,6 @@ class TestCreateMaterializedView(DAOTestCase):
             raises(ValueError)
         )
 
-    def test_create_materialized_view_with_invalid_dependencies(self):
-        assert_that(
-            calling(create_materialized_view).with_args(
-                'testview', select([1]), dependencies=[object]
-            ),
-            raises(ValueError)
-        )
-
     def test_create_materialized_view_with_invalid_indexes(self):
         assert_that(
             calling(create_materialized_view).with_args(
@@ -58,72 +49,12 @@ class TestCreateMaterializedView(DAOTestCase):
             raises(ValueError)
         )
 
-
-class TestMaterializedView(DAOTestCase):
-    def _create_view_class(
-        self, func, name=None, selectable=None, dependencies=None, indexes=None
-    ):
-        class _(MaterializedView):
-            __view__ = (
-                func(name, selectable, dependencies=dependencies, indexes=indexes)
-                if callable(func)
-                else func
-            )
-
-        return _
-
-    def test_view_init_table(self):
-        assert_that(
-            calling(self._create_view_class).with_args(
-                create_materialized_view, name='test', selectable=select([1])
-            ),
-            not_(raises(InvalidRequestError)),
-        )
-
-    def test_view_class_creation(self):
-        view = self._create_view_class(create_materialized_view, "view", select([1]))
-        assert_that(issubclass(view, MaterializedView), equal_to(True))
-
-    def test_view_init_with_none(self):
-        assert_that(
-            calling(self._create_view_class).with_args(None),
-            raises(InvalidRequestError),
-        )
-
-    def test_view_without_helper_function(self):
-        def some_func(name, selectable, dependencies=None, indexes=None):
-            return "bad return"
-
-        assert_that(
-            calling(self._create_view_class).with_args(some_func, "view", select([1])),
-            raises(InvalidRequestError)
-        )
-
-    def test_view_init_with_invalid_view(self):
-        assert_that(
-            calling(self._create_view_class).with_args((None, None)),
-            raises(InvalidRequestError),
-        )
-
-    def test_view_init_without_view_attribute(self):
-        def _create_class():
+    def test_create_materialized_view_class(self):
+        def create_view():
             class _(MaterializedView):
-                pass
+                __table__ = create_materialized_view('testview', select([1]))
 
             return _
 
-        assert_that(calling(_create_class), raises(InvalidRequestError))
-
-    def test_view_dependencies_event_correctly_bound(self):
-        class MockModel(Base):
-            __tablename__ = 'mock_model'
-            id = Column(Integer, primary_key=True)
-
-        view = self._create_view_class(
-            create_materialized_view, "view", select([1]), dependencies=[MockModel]
-        )
-        assert_that(view.autorefresh, equal_to(True))
-
-    def test_view_dependencies_no_event_bound(self):
-        view = self._create_view_class(create_materialized_view, "view", select([1]))
-        assert_that(view.autorefresh, equal_to(False))
+        view = create_view()
+        assert_that(issubclass(view, MaterializedView), equal_to(True))

--- a/xivo_dao/resources/endpoint_sip/persistor.py
+++ b/xivo_dao/resources/endpoint_sip/persistor.py
@@ -1,9 +1,10 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.orm import joinedload
 
 from xivo_dao.alchemy.endpoint_sip import EndpointSIP
+from xivo_dao.alchemy.endpoint_sip_options_view import EndpointSIPOptionsView
 from xivo_dao.helpers import errors, generators
 from xivo_dao.helpers.persistor import BasePersistor
 from xivo_dao.resources.line.fixes import LineFixes
@@ -56,14 +57,17 @@ class SipPersistor(CriteriaBuilderMixin, BasePersistor):
         self._fill_default_values(sip)
         self.session.add(sip)
         self.session.flush()
+        EndpointSIPOptionsView.refresh()
         return sip
 
     def edit(self, sip):
         self.persist(sip)
+        EndpointSIPOptionsView.refresh()
         self._fix_associated(sip)
 
     def delete(self, sip):
         self.session.delete(sip)
+        EndpointSIPOptionsView.refresh()
         self._fix_associated(sip)
 
     def _fix_associated(self, sip):


### PR DESCRIPTION
Changes:
-----------
1. Use SQLAlchemy-utils to manage views instead of custom implementation
2. Replace database trigger to refresh view by a manual refresh in needed DAO (to avoid too many refreshes)