### PR TITLE
WAZO-3251: only refresh materialized view when object is updated, created or deleted

### DIFF
--- a/xivo_dao/helpers/db_views.py
+++ b/xivo_dao/helpers/db_views.py
@@ -172,7 +172,7 @@ class _MaterializedViewMeta(DeclarativeMeta):
 
             @listens_for(Session, 'before_commit')
             def _before_session_commit_handler(session):
-                for obj in session:
+                for obj in (session.dirty | session.new | session.deleted):
                     if isinstance(obj, tuple(targets)):
                         self.refresh(concurrently=True)
                         return


### PR DESCRIPTION
Why:

* Before, it would also update the view everytime the object would be in the session, including during fetch, which would trigger too many refreshes