### PR TITLE
Use post_flush trigger for Materialized Views as before_commit does n…

### DIFF
--- a/xivo_dao/alchemy/endpoint_sip_options_view.py
+++ b/xivo_dao/alchemy/endpoint_sip_options_view.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import select, join, cast, literal, func, String, Index, text
@@ -85,7 +85,7 @@ class EndpointSIPOptionsView(MaterializedView):
     __view__ = create_materialized_view(
         'endpoint_sip_options_view',
         _generate_selectable(),
-        dependencies=[EndpointSIPSectionOption],
+        dependencies=(EndpointSIPSectionOption, EndpointSIP),
         indexes=[
             Index('endpoint_sip_options_view__idx_root', text('root'), unique=True),
         ],

--- a/xivo_dao/alchemy/tests/test_endpoint_sip.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -393,7 +393,7 @@ class TestCallerId(DAOTestCase):
         sip = self.add_endpoint_sip(
             templates=[template1, template2], caller_id='template3'
         )
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        self.session.flush()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template3'))
@@ -402,7 +402,7 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(caller_id='template1')
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        self.session.flush()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template1'))
@@ -412,7 +412,7 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(templates=[template0])
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        self.session.flush()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template0'))
@@ -420,7 +420,7 @@ class TestCallerId(DAOTestCase):
     def test_callerid_inheritance(self):
         template1 = self.add_endpoint_sip(caller_id='template1')
         sip = self.add_endpoint_sip(templates=[template1])
-        EndpointSIPOptionsView.refresh(concurrently=True)  # Simulate a database commit
+        self.session.flush()
 
         assert_that(
             sip.get_option_value('callerid'),

--- a/xivo_dao/alchemy/tests/test_endpoint_sip.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip.py
@@ -393,7 +393,6 @@ class TestCallerId(DAOTestCase):
         sip = self.add_endpoint_sip(
             templates=[template1, template2], caller_id='template3'
         )
-        self.session.flush()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template3'))
@@ -402,7 +401,6 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(caller_id='template1')
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
-        self.session.flush()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template1'))
@@ -412,7 +410,6 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(templates=[template0])
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
-        self.session.flush()
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template0'))
@@ -420,7 +417,6 @@ class TestCallerId(DAOTestCase):
     def test_callerid_inheritance(self):
         template1 = self.add_endpoint_sip(caller_id='template1')
         sip = self.add_endpoint_sip(templates=[template1])
-        self.session.flush()
 
         assert_that(
             sip.get_option_value('callerid'),

--- a/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
@@ -66,3 +66,22 @@ class TestView(DAOTestCase):
         )
         assert_that(result.root, equal_to(sip.uuid))
         assert_that(result.options, has_entries(first='value1', second='value2'))
+
+    def test_view_dont_update_on_get(self):
+        sip = self.add_endpoint_sip(
+            endpoint_section_options=[('test', 'old_value')]
+        )
+
+        assert_that(sip.get_option_value('test'), equal_to('old_value'))
+
+        sip.endpoint_section_options = [('test', 'new_value')]
+
+        # view should not be updated, because no flush occurred
+        assert_that(sip.get_option_value('test'), equal_to('old_value'))
+
+        self.session.add(sip)
+        self.session.flush()
+        self.session.expire(sip)
+
+        # view is only updated when a EndpointSIPOption object is updated
+        assert_that(sip.get_option_value('test'), equal_to('new_value'))

--- a/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip_options_view.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -18,7 +18,7 @@ class TestView(DAOTestCase):
 
         assert_that(sip.get_option_value('key'), equal_to(None))
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        self.session.flush()
         self.session.expire(sip)
 
         assert_that(sip.get_option_value('key'), equal_to('value'))
@@ -34,7 +34,7 @@ class TestView(DAOTestCase):
         template3.endpoint_section_options = [('templ3', 'third')]
         sip.endpoint_section_options = [('sip', 'fourth')]
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        self.session.flush()
 
         assert_that(
             sip._options,
@@ -48,7 +48,7 @@ class TestView(DAOTestCase):
         template.endpoint_section_options = [('option', 'template')]
         sip.endpoint_section_options = [('option', 'sip')]
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        self.session.flush()
 
         assert_that(sip.get_option_value('option'), equal_to('sip'))
 
@@ -59,7 +59,7 @@ class TestView(DAOTestCase):
         template.endpoint_section_options = [('second', 'value2')]
         sip.endpoint_section_options = [('first', 'value1')]
 
-        EndpointSIPOptionsView.refresh()  # Simulate a database commit
+        self.session.flush()
 
         result = (
             self.session.query(EndpointSIPOptionsView).filter_by(root=sip.uuid).first()

--- a/xivo_dao/helpers/db_views.py
+++ b/xivo_dao/helpers/db_views.py
@@ -171,7 +171,7 @@ class _MaterializedViewMeta(DeclarativeMeta):
         @listens_for(Session, 'after_flush')
         def _before_session_commit_handler(session: Session, flush_context: UOWTransaction) -> None:
             for obj in session.dirty | session.new | session.deleted:
-                if isinstance(obj, targets):
+                if isinstance(obj, tuple(targets)):
                     # Cannot call `refresh_materialized_view` as it will try to flush again.
                     session.execute(
                         text(f'REFRESH MATERIALIZED VIEW CONCURRENTLY {self.__table__.fullname}')

--- a/xivo_dao/helpers/db_views.py
+++ b/xivo_dao/helpers/db_views.py
@@ -178,9 +178,9 @@ class _MaterializedViewMeta(DeclarativeMeta):
                     )
                     return
 
-            self._view_dependencies_handler = staticmethod(
-                _before_session_commit_handler
-            )
+        self._view_dependencies_handler = staticmethod(
+            _before_session_commit_handler
+        )
 
     @property
     def autorefresh(self):

--- a/xivo_dao/helpers/db_views.py
+++ b/xivo_dao/helpers/db_views.py
@@ -1,12 +1,13 @@
 # Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import Column, MetaData, PrimaryKeyConstraint, Table, Index
+from sqlalchemy import Column, MetaData, PrimaryKeyConstraint, Table, Index, text
 from sqlalchemy.ext import compiler
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.event import listens_for, listen, contains
 from sqlalchemy.exc import InvalidRequestError, NoInspectionAvailable
 from sqlalchemy.inspection import inspect
+from sqlalchemy.orm.unitofwork import UOWTransaction
 from sqlalchemy.sql.ddl import DDLElement
 from sqlalchemy.sql.selectable import Selectable
 
@@ -164,17 +165,18 @@ class _MaterializedViewMeta(DeclarativeMeta):
         _refresh_materialized_view(Session(), self.__table__.fullname, concurrently)
 
     def _track_dependencies(self):
-        if not hasattr(self, '_view_dependencies'):
+        if not (targets := getattr(self, '_view_dependencies', None)):
             return
-        targets = self._view_dependencies
-        if targets:
 
-            @listens_for(Session, 'before_commit')
-            def _before_session_commit_handler(session):
-                for obj in session.dirty | session.new | session.deleted:
-                    if isinstance(obj, tuple(targets)):
-                        self.refresh(concurrently=True)
-                        return
+        @listens_for(Session, 'after_flush')
+        def _before_session_commit_handler(session: Session, flush_context: UOWTransaction) -> None:
+            for obj in session.dirty | session.new | session.deleted:
+                if isinstance(obj, targets):
+                    # Cannot call `refresh_materialized_view` as it will try to flush again.
+                    session.execute(
+                        text(f'REFRESH MATERIALIZED VIEW CONCURRENTLY {self.__table__.fullname}')
+                    )
+                    return
 
             self._view_dependencies_handler = staticmethod(
                 _before_session_commit_handler
@@ -182,7 +184,7 @@ class _MaterializedViewMeta(DeclarativeMeta):
 
     @property
     def autorefresh(self):
-        return contains(Session, 'before_commit', self._view_dependencies_handler)
+        return contains(Session, 'after_flush', self._view_dependencies_handler)
 
 
 class MaterializedView(Base, metaclass=_MaterializedViewMeta):


### PR DESCRIPTION
reason: because of autoflush the list of changes is always empty in before_commit