### PR TITLE
Fix users search with limit but without offset

### DIFF
--- a/xivo_dao/resources/user/persistor.py
+++ b/xivo_dao/resources/user/persistor.py
@@ -71,7 +71,7 @@ class UserPersistor(CriteriaBuilderMixin, BasePersistor):
     def search_collated(self, parameters):
         order = parameters.pop('order', None)
         limit = parameters.pop('limit', None)
-        offset = parameters.pop('offset', None)
+        offset = parameters.pop('offset', 0)
         reverse = False if parameters.pop('direction', 'asc') == 'asc' else True
         result = self.search(parameters)
         if order:
@@ -83,7 +83,7 @@ class UserPersistor(CriteriaBuilderMixin, BasePersistor):
         else:
             users = result.items
 
-        if not offset or not limit:
+        if not limit:
             return SearchResult(result.total, users[offset:])
         else:
             return SearchResult(result.total, users[offset:offset + limit])

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -593,6 +593,12 @@ class TestSearchGivenMultipleUsers(TestSearch):
             expected_collated_all_resto, description='resto', order='firstname'
         )
 
+    def test_when_limiting_and_ordering(self):
+        expected = SearchResult(7, [self.user1])
+
+        self.assert_search_returns_result(expected, limit=1, order='firstname')
+        self.assert_search_collated_returns_result(expected, limit=1, order='firstname')
+
     def test_when_sorting_then_returns_result_in_ascending_order(self):
         expected = SearchResult(
             7,


### PR DESCRIPTION
When users search was processed with limit but without offset, limit parameter was ignored. 
Issue fixed and test added.