### PR TITLE
Add missing foreign keys and delete function on tenant DAO

### DIFF
--- a/xivo_dao/alchemy/context.py
+++ b/xivo_dao/alchemy/context.py
@@ -30,6 +30,7 @@ class Context(Base):
         ForeignKeyConstraint(
             ('tenant_uuid',),
             ('tenant.uuid',),
+            ondelete='CASCADE',
         ),
         Index('context__idx__tenant_uuid', 'tenant_uuid'),
     )

--- a/xivo_dao/alchemy/contextinclude.py
+++ b/xivo_dao/alchemy/contextinclude.py
@@ -17,8 +17,16 @@ class ContextInclude(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
+            onupdate='CASCADE',
+        ),
+        ForeignKeyConstraint(
+            ('include',),
+            ('context.name',),
+            ondelete='CASCADE',
+            onupdate='CASCADE',
         ),
     )
+
     context = Column(String(39), primary_key=True)
     include = Column(String(39), primary_key=True)
     priority = Column(Integer, nullable=False, server_default='0')

--- a/xivo_dao/alchemy/contextinclude.py
+++ b/xivo_dao/alchemy/contextinclude.py
@@ -1,6 +1,7 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column
 from sqlalchemy.types import Integer, String
@@ -11,7 +12,13 @@ from xivo_dao.helpers.db_manager import Base
 class ContextInclude(Base):
 
     __tablename__ = 'contextinclude'
-
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+        ),
+    )
     context = Column(String(39), primary_key=True)
     include = Column(String(39), primary_key=True)
     priority = Column(Integer, nullable=False, server_default='0')

--- a/xivo_dao/alchemy/contextmember.py
+++ b/xivo_dao/alchemy/contextmember.py
@@ -1,6 +1,7 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.schema import Column, PrimaryKeyConstraint, Index
 from sqlalchemy.types import String
 
@@ -14,6 +15,11 @@ class ContextMember(Base):
         PrimaryKeyConstraint('context', 'type', 'typeval', 'varname'),
         Index('contextmember__idx__context', 'context'),
         Index('contextmember__idx__context_type', 'context', 'type'),
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+        ),
     )
 
     context = Column(String(39))

--- a/xivo_dao/alchemy/contextmember.py
+++ b/xivo_dao/alchemy/contextmember.py
@@ -19,6 +19,7 @@ class ContextMember(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
+            onupdate='CASCADE',
         ),
     )
 

--- a/xivo_dao/alchemy/contextnumbers.py
+++ b/xivo_dao/alchemy/contextnumbers.py
@@ -1,7 +1,8 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # Copyright (C) 2016 Proformatique Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.schema import Column
 from sqlalchemy.sql import case
@@ -13,6 +14,13 @@ from xivo_dao.helpers.db_manager import Base
 class ContextNumbers(Base):
 
     __tablename__ = 'contextnumbers'
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+        ),
+    )
 
     context = Column(String(39), primary_key=True)
     type = Column(Enum('user', 'group', 'queue', 'meetme', 'incall',

--- a/xivo_dao/alchemy/contextnumbers.py
+++ b/xivo_dao/alchemy/contextnumbers.py
@@ -19,6 +19,7 @@ class ContextNumbers(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
+            onupdate='CASCADE',
         ),
     )
 

--- a/xivo_dao/alchemy/tests/test_contextinclude.py
+++ b/xivo_dao/alchemy/tests/test_contextinclude.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -36,8 +36,9 @@ class TestCreator(DAOTestCase):
 
     def test_included_context_set_include(self):
         context = self.add_context()
-        context_include = ContextInclude(included_context=context, context='random')
+        include = self.add_context()
+        context_include = ContextInclude(included_context=include, context=context.name)
         self.session.add(context_include)
         self.session.flush()
 
-        assert_that(context_include, has_properties(include=context.name))
+        assert_that(context_include, has_properties(include=include.name))

--- a/xivo_dao/alchemy/tests/test_voicemail.py
+++ b/xivo_dao/alchemy/tests/test_voicemail.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import and_
@@ -12,32 +12,35 @@ from ..voicemail import Voicemail
 class TestGetOldNumberContext(DAOTestCase):
 
     def test_when_number_context_are_modified(self):
-        voicemail = self.add_voicemail(number='1000', context='default')
+        context = self.add_context(name='default')
+        voicemail = self.add_voicemail(number='1000', context=context.name)
         voicemail.number = '1001'
         voicemail.context = 'not_default'
 
         old_number, old_context = voicemail.get_old_number_context()
 
         assert_that(old_number, equal_to('1000'))
-        assert_that(old_context, equal_to('default'))
+        assert_that(old_context, equal_to(context.name))
 
     def test_when_only_number_is_modified(self):
-        voicemail = self.add_voicemail(number='1000', context='default')
+        context = self.add_context(name='default')
+        voicemail = self.add_voicemail(number='1000', context=context.name)
         voicemail.number = '1001'
 
         old_number, old_context = voicemail.get_old_number_context()
 
         assert_that(old_number, equal_to('1000'))
-        assert_that(old_context, equal_to('default'))
+        assert_that(old_context, equal_to(context.name))
 
     def test_when_only_context_is_modified(self):
-        voicemail = self.add_voicemail(number='1000', context='default')
+        context = self.add_context(name='default')
+        voicemail = self.add_voicemail(number='1000', context=context.name)
         voicemail.context = 'not_default'
 
         old_number, old_context = voicemail.get_old_number_context()
 
         assert_that(old_number, equal_to('1000'))
-        assert_that(old_context, equal_to('default'))
+        assert_that(old_context, equal_to(context.name))
 
 
 class TestTenantUUID(DAOTestCase):

--- a/xivo_dao/alchemy/voicemail.py
+++ b/xivo_dao/alchemy/voicemail.py
@@ -1,7 +1,7 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import sql, Boolean
+from sqlalchemy import sql, Boolean, ForeignKeyConstraint
 
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -33,6 +33,11 @@ class Voicemail(Base):
         PrimaryKeyConstraint('uniqueid'),
         UniqueConstraint('mailbox', 'context'),
         Index('voicemail__idx__context', 'context'),
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+        ),
     )
 
     uniqueid = Column(Integer)

--- a/xivo_dao/alchemy/voicemail.py
+++ b/xivo_dao/alchemy/voicemail.py
@@ -37,6 +37,7 @@ class Voicemail(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
+            onupdate='CASCADE',
         ),
     )
 

--- a/xivo_dao/resources/tenant/dao.py
+++ b/xivo_dao/resources/tenant/dao.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import daosession
@@ -35,3 +35,8 @@ def get_by(session, tenant_uuids=None, **criteria):
 @daosession
 def search(session, tenant_uuids=None, **parameters):
     return Persistor(session, tenant_search, tenant_uuids).search(parameters)
+
+
+@daosession
+def delete(session, tenant):
+    Persistor(session, tenant_search).delete(tenant)

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -106,7 +106,7 @@ class TestFind(TestUser):
             preprocess_subroutine='preprocess_subroutine',
         )
 
-        voicemail_row = self.add_voicemail(mailbox='1234', context='default')
+        voicemail_row = self.add_voicemail(mailbox='1234')
         self.link_user_and_voicemail(user_row, voicemail_row.uniqueid)
 
         user = user_dao.find(user_row.id)

--- a/xivo_dao/resources/user_voicemail/tests/test_dao.py
+++ b/xivo_dao/resources/user_voicemail/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -20,14 +20,14 @@ from .. import dao as user_voicemail_dao
 
 class TestUserVoicemail(DAOTestCase):
 
-    def create_user_and_voicemail(self, firstname, exten, context):
-        user_row = self.add_user(enablevoicemail=1, firstname='King')
-        voicemail_row = self.add_voicemail(mailbox='1000', context='default')
+    def create_user_and_voicemail(self, firstname, exten):
+        user_row = self.add_user(enablevoicemail=1, firstname=firstname)
+        voicemail_row = self.add_voicemail(mailbox=exten)
         self.link_user_and_voicemail(user_row, voicemail_row.uniqueid)
         return user_row, voicemail_row
 
     def prepare_voicemail(self, number):
-        voicemail_row = self.add_voicemail(mailbox=number, context='default')
+        voicemail_row = self.add_voicemail(mailbox=number)
         return voicemail_row.uniqueid
 
 
@@ -35,7 +35,7 @@ class TestAssociateUserVoicemail(TestUserVoicemail):
 
     def test_associate(self):
         user_row = self.add_user()
-        voicemail_row = self.add_voicemail(mailbox='1000', context='default')
+        voicemail_row = self.add_voicemail(mailbox='1000')
 
         user_voicemail_dao.associate(user_row, voicemail_row)
 
@@ -66,7 +66,7 @@ class TestUserVoicemailGetByUserId(TestUserVoicemail):
         self.assertRaises(NotFoundError, user_voicemail_dao.get_by_user_id, user_line.user.id)
 
     def test_get_by_user_id_with_voicemail(self):
-        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000', context='default')
+        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000')
 
         result = user_voicemail_dao.get_by_user_id(user_row.id)
 
@@ -97,7 +97,7 @@ class TestUserVoicemailFindByUserId(TestUserVoicemail):
         assert_that(result, none())
 
     def test_find_by_user_id_with_voicemail(self):
-        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000', context='default')
+        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000')
 
         result = user_voicemail_dao.find_by_user_id(user_row.id)
 
@@ -114,7 +114,7 @@ class TestUserVoicemailFindAllByVoicemailId(TestUserVoicemail):
         assert_that(result, contains())
 
     def test_given_voicemail_has_no_user_associated_then_returns_empty_list(self):
-        voicemail_row = self.add_voicemail(mailbox='1000', context='default')
+        voicemail_row = self.add_voicemail(mailbox='1000')
 
         result = user_voicemail_dao.find_all_by_voicemail_id(voicemail_row.uniqueid)
 
@@ -148,7 +148,7 @@ class TestUserVoicemailFindAllByVoicemailId(TestUserVoicemail):
 class TestDissociateUserVoicemail(TestUserVoicemail):
 
     def test_dissociate(self):
-        voicemail_row = self.add_voicemail(mailbox='1000', context='default')
+        voicemail_row = self.add_voicemail(mailbox='1000')
         user_row = self.add_user(voicemailid=voicemail_row.uniqueid,
                                  enablevoicemail=1)
 
@@ -159,8 +159,8 @@ class TestDissociateUserVoicemail(TestUserVoicemail):
         assert_that(result.enablevoicemail, equal_to(0))
 
     def test_dissociate_not_associated(self):
-        voicemail1 = self.add_voicemail(mailbox='1000', context='default')
-        voicemail2 = self.add_voicemail(mailbox='1001', context='default')
+        voicemail1 = self.add_voicemail(mailbox='1000')
+        voicemail2 = self.add_voicemail(mailbox='1001')
         user = self.add_user(voicemailid=voicemail1.uniqueid,
                              enablevoicemail=1)
 

--- a/xivo_dao/tests/test_asterisk_conf_dao.py
+++ b/xivo_dao/tests/test_asterisk_conf_dao.py
@@ -627,12 +627,14 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
         ))
 
     def test_find_contextincludes_settings(self):
-        context = 'default'
-        self.add_context_include(context='koki')
-        context_include = self.add_context_include(context=context)
-        self.add_context_include(context='toto')
+        context_default = self.add_context(name='default')
+        context_koki = self.add_context(name='koki')
+        context_toto = self.add_context(name='toto')
+        self.add_context_include(context=context_koki.name)
+        context_include = self.add_context_include(context=context_default.name)
+        self.add_context_include(context=context_toto.name)
 
-        context = asterisk_conf_dao.find_contextincludes_settings(context)
+        context = asterisk_conf_dao.find_contextincludes_settings(context_default.name)
 
         assert_that(context, contains_inanyorder(
             has_entries(

--- a/xivo_dao/tests/test_dao.py
+++ b/xivo_dao/tests/test_dao.py
@@ -348,8 +348,12 @@ class ItemInserter:
         return context
 
     def add_context_include(self, **kwargs):
-        kwargs.setdefault('context', self._random_name())
-        kwargs.setdefault('include', self._random_name())
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
+        if not kwargs.get('include'):
+            include = self.add_context()
+            kwargs['include'] = include.name
         kwargs.setdefault('priority', 0)
 
         context_include = ContextInclude(**kwargs)
@@ -363,7 +367,9 @@ class ItemInserter:
         return context_number
 
     def add_context_member(self, **kwargs):
-        kwargs.setdefault('context', 'default')
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
         kwargs.setdefault('type', 'user')
         kwargs.setdefault('varname', 'context')
 
@@ -747,7 +753,9 @@ class ItemInserter:
     def add_voicemail(self, **kwargs):
         if not kwargs.get('number'):
             kwargs.setdefault('mailbox', ''.join(random.choice('0123456789_*X.') for _ in range(6)))
-        kwargs.setdefault('context', 'unittest')
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
         kwargs.setdefault('uniqueid', self._generate_int())
 
         voicemail = VoicemailSchema(**kwargs)

--- a/xivo_dao/tests/test_user_dao.py
+++ b/xivo_dao/tests/test_user_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, calling, equal_to, raises
@@ -10,21 +10,23 @@ from xivo_dao.tests.test_dao import DAOTestCase
 class TestUserFeaturesDAO(DAOTestCase):
 
     def test_get_user_by_number_context(self):
-        context, number = 'default', '1234'
+        context = self.add_context(name='default')
+        number = '1234'
         user_line = self.add_user_line_with_exten(exten=number,
-                                                  context=context)
+                                                  context=context.name)
 
-        user = user_dao.get_user_by_number_context(number, context)
+        user = user_dao.get_user_by_number_context(number, context.name)
 
         assert_that(user.id, equal_to(user_line.user.id))
 
     def test_get_user_by_number_context_line_commented(self):
-        context, number = 'default', '1234'
+        context = self.add_context(name='default')
+        number = '1234'
         self.add_user_line_with_exten(exten=number,
-                                      context=context,
+                                      context=context.name,
                                       commented_line=1)
 
-        self.assertRaises(LookupError, user_dao.get_user_by_number_context, number, context)
+        self.assertRaises(LookupError, user_dao.get_user_by_number_context, number, context.name)
 
     def test_get_user_by_agent_id(self):
         agent_id = 42


### PR DESCRIPTION
When a tenant was deleted, the context (and their related tables contextnumbers, contextmember, contextinclude) and the voicemail were not deleted.

Depends-On: https://github.com/wazo-platform/xivo-manage-db/pull/201