### PR TITLE
debian: pin sqlalchemy-utils to prevent upgrade traceback

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Depends: ${python3:Depends},
          ${misc:Depends},
          xivo-lib-python-python3,
          python3-sqlalchemy,
-         python3-sqlalchemy-utils,
+         python3-sqlalchemy-utils (>= 0.36.8),
          python3-unidecode
 Description: Wazo telephony systems library for directories manager
  Wazo is a system based on a powerful IPBX, to bring an easy to


### PR DESCRIPTION
why: When upgrading from Buster to Bullseye, sqlalchemy-utils is
upgraded after wazo services. So if the service use new method, it will
raise an error and fail the installation of this package.

Fortunally, on most case, the command after is dist-upgrade and
will fix thing. But it's still worrying for a sysadmin