### PR TITLE
hint: always use uppercase

### DIFF
--- a/xivo_dao/resources/func_key/hint_dao.py
+++ b/xivo_dao/resources/func_key/hint_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy import (
@@ -103,11 +103,11 @@ def user_shared_hints(session):
             if line.endpoint_custom_id:
                 ifaces.append(line.name)
             elif line.endpoint_sip_uuid:
-                ifaces.append(f'pjsip/{line.name}')
+                ifaces.append(f'PJSIP/{line.name}')
             elif line.endpoint_sccp_id:
-                ifaces.append(f'sccp/{line.name}')
+                ifaces.append(f'SCCP/{line.name}')
             else:
-                ifaces.append(f'custom/{line.name}')
+                ifaces.append(f'CUSTOM/{line.name}')
 
         if not ifaces:
             continue

--- a/xivo_dao/resources/func_key/tests/test_hint_dao.py
+++ b/xivo_dao/resources/func_key/tests/test_hint_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -554,7 +554,7 @@ class TestUserSharedHints(TestHints):
 
         assert_that(
             results[0].argument,
-            equal_to(f'Custom:{user.uuid}-mobile&pjsip/{line_1.name}&{line_2.name}&sccp/{line_3.name}'),
+            equal_to(f'Custom:{user.uuid}-mobile&PJSIP/{line_1.name}&{line_2.name}&SCCP/{line_3.name}'),
         )
 
     def test_no_line(self):


### PR DESCRIPTION
why: when user sharing device state from asterisk, device state is
shared with case sensitive and all custom hints must be in uppercase to
be updated correctly

note: sharing device state is used for horizontal scaling