### PR TITLE
Add missing fks related to context and delete function on tenant DAO

### DIFF
--- a/xivo_dao/alchemy/context.py
+++ b/xivo_dao/alchemy/context.py
@@ -30,6 +30,7 @@ class Context(Base):
         ForeignKeyConstraint(
             ('tenant_uuid',),
             ('tenant.uuid',),
+            ondelete='CASCADE',
         ),
         Index('context__idx__tenant_uuid', 'tenant_uuid'),
     )

--- a/xivo_dao/alchemy/contextinclude.py
+++ b/xivo_dao/alchemy/contextinclude.py
@@ -17,7 +17,6 @@ class ContextInclude(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
-            onupdate='CASCADE',
         ),
     )
 

--- a/xivo_dao/alchemy/contextinclude.py
+++ b/xivo_dao/alchemy/contextinclude.py
@@ -1,6 +1,7 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column
 from sqlalchemy.types import Integer, String
@@ -11,6 +12,14 @@ from xivo_dao.helpers.db_manager import Base
 class ContextInclude(Base):
 
     __tablename__ = 'contextinclude'
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+            onupdate='CASCADE',
+        ),
+    )
 
     context = Column(String(39), primary_key=True)
     include = Column(String(39), primary_key=True)

--- a/xivo_dao/alchemy/contextmember.py
+++ b/xivo_dao/alchemy/contextmember.py
@@ -1,6 +1,7 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.schema import Column, PrimaryKeyConstraint, Index
 from sqlalchemy.types import String
 
@@ -14,6 +15,12 @@ class ContextMember(Base):
         PrimaryKeyConstraint('context', 'type', 'typeval', 'varname'),
         Index('contextmember__idx__context', 'context'),
         Index('contextmember__idx__context_type', 'context', 'type'),
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+            onupdate='CASCADE',
+        ),
     )
 
     context = Column(String(39))

--- a/xivo_dao/alchemy/contextmember.py
+++ b/xivo_dao/alchemy/contextmember.py
@@ -19,7 +19,6 @@ class ContextMember(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
-            onupdate='CASCADE',
         ),
     )
 

--- a/xivo_dao/alchemy/contextnumbers.py
+++ b/xivo_dao/alchemy/contextnumbers.py
@@ -1,7 +1,8 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # Copyright (C) 2016 Proformatique Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.schema import Column
 from sqlalchemy.sql import case
@@ -13,6 +14,14 @@ from xivo_dao.helpers.db_manager import Base
 class ContextNumbers(Base):
 
     __tablename__ = 'contextnumbers'
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+            onupdate='CASCADE',
+        ),
+    )
 
     context = Column(String(39), primary_key=True)
     type = Column(Enum('user', 'group', 'queue', 'meetme', 'incall',

--- a/xivo_dao/alchemy/contextnumbers.py
+++ b/xivo_dao/alchemy/contextnumbers.py
@@ -19,7 +19,6 @@ class ContextNumbers(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
-            onupdate='CASCADE',
         ),
     )
 

--- a/xivo_dao/alchemy/tests/test_contextinclude.py
+++ b/xivo_dao/alchemy/tests/test_contextinclude.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -36,8 +36,9 @@ class TestCreator(DAOTestCase):
 
     def test_included_context_set_include(self):
         context = self.add_context()
-        context_include = ContextInclude(included_context=context, context='random')
+        include = self.add_context()
+        context_include = ContextInclude(included_context=include, context=context.name)
         self.session.add(context_include)
         self.session.flush()
 
-        assert_that(context_include, has_properties(include=context.name))
+        assert_that(context_include, has_properties(include=include.name))

--- a/xivo_dao/resources/context/tests/test_dao.py
+++ b/xivo_dao/resources/context/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -336,7 +336,6 @@ class TestEdit(DAOTestCase):
                                              enabled=False))
 
         context = context_dao.get(context.id)
-        context.name = 'OtherContext'
         context.label = 'Other Context Label'
         context.type = 'incall'
         context.user_ranges = [ContextNumbers(start='4000', end='4999')]
@@ -354,7 +353,6 @@ class TestEdit(DAOTestCase):
         assert_that(context, has_properties(
             id=is_not(none()),
             tenant_uuid=tenant.uuid,
-            name='OtherContext',
             label='Other Context Label',
             type='incall',
             user_ranges=contains(has_properties(start='4000', end='4999')),

--- a/xivo_dao/resources/tenant/dao.py
+++ b/xivo_dao/resources/tenant/dao.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.helpers.db_manager import daosession
@@ -35,3 +35,8 @@ def get_by(session, tenant_uuids=None, **criteria):
 @daosession
 def search(session, tenant_uuids=None, **parameters):
     return Persistor(session, tenant_search, tenant_uuids).search(parameters)
+
+
+@daosession
+def delete(session, tenant):
+    Persistor(session, tenant_search).delete(tenant)

--- a/xivo_dao/tests/test_asterisk_conf_dao.py
+++ b/xivo_dao/tests/test_asterisk_conf_dao.py
@@ -627,12 +627,14 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
         ))
 
     def test_find_contextincludes_settings(self):
-        context = 'default'
-        self.add_context_include(context='koki')
-        context_include = self.add_context_include(context=context)
-        self.add_context_include(context='toto')
+        context_default = self.add_context(name='default')
+        context_koki = self.add_context(name='koki')
+        context_toto = self.add_context(name='toto')
+        self.add_context_include(context=context_koki.name)
+        context_include = self.add_context_include(context=context_default.name)
+        self.add_context_include(context=context_toto.name)
 
-        context = asterisk_conf_dao.find_contextincludes_settings(context)
+        context = asterisk_conf_dao.find_contextincludes_settings(context_default.name)
 
         assert_that(context, contains_inanyorder(
             has_entries(

--- a/xivo_dao/tests/test_dao.py
+++ b/xivo_dao/tests/test_dao.py
@@ -348,8 +348,12 @@ class ItemInserter:
         return context
 
     def add_context_include(self, **kwargs):
-        kwargs.setdefault('context', self._random_name())
-        kwargs.setdefault('include', self._random_name())
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
+        if not kwargs.get('include'):
+            include = self.add_context()
+            kwargs['include'] = include.name
         kwargs.setdefault('priority', 0)
 
         context_include = ContextInclude(**kwargs)
@@ -363,7 +367,9 @@ class ItemInserter:
         return context_number
 
     def add_context_member(self, **kwargs):
-        kwargs.setdefault('context', 'default')
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
         kwargs.setdefault('type', 'user')
         kwargs.setdefault('varname', 'context')
 

--- a/xivo_dao/tests/test_user_dao.py
+++ b/xivo_dao/tests/test_user_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, calling, equal_to, raises
@@ -10,21 +10,23 @@ from xivo_dao.tests.test_dao import DAOTestCase
 class TestUserFeaturesDAO(DAOTestCase):
 
     def test_get_user_by_number_context(self):
-        context, number = 'default', '1234'
+        context = self.add_context(name='default')
+        number = '1234'
         user_line = self.add_user_line_with_exten(exten=number,
-                                                  context=context)
+                                                  context=context.name)
 
-        user = user_dao.get_user_by_number_context(number, context)
+        user = user_dao.get_user_by_number_context(number, context.name)
 
         assert_that(user.id, equal_to(user_line.user.id))
 
     def test_get_user_by_number_context_line_commented(self):
-        context, number = 'default', '1234'
+        context = self.add_context(name='default')
+        number = '1234'
         self.add_user_line_with_exten(exten=number,
-                                      context=context,
+                                      context=context.name,
                                       commented_line=1)
 
-        self.assertRaises(LookupError, user_dao.get_user_by_number_context, number, context)
+        self.assertRaises(LookupError, user_dao.get_user_by_number_context, number, context.name)
 
     def test_get_user_by_agent_id(self):
         agent_id = 42


### PR DESCRIPTION
When a tenant was deleted, the context (and their related tables contextnumbers, contextmember, contextinclude) were not deleted.

Depends-On: https://github.com/wazo-platform/xivo-manage-db/pull/204