### PR TITLE
Add missing fks user_line and linefeatures

### DIFF
--- a/xivo_dao/alchemy/linefeatures.py
+++ b/xivo_dao/alchemy/linefeatures.py
@@ -3,7 +3,7 @@
 
 import re
 
-from sqlalchemy import sql, func
+from sqlalchemy import sql, func, ForeignKeyConstraint
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.expression import bindparam, select
@@ -72,6 +72,12 @@ class LineFeatures(Base):
         Index('linefeatures__idx__endpoint_custom_id', 'endpoint_custom_id'),
         Index('linefeatures__idx__application_uuid', 'application_uuid'),
         Index('linefeatures__idx__endpoint_sip_uuid', 'endpoint_sip_uuid'),
+        ForeignKeyConstraint(
+            ('context',),
+            ('context.name',),
+            ondelete='CASCADE',
+            onupdate='CASCADE',
+        ),
     )
 
     id = Column(Integer)

--- a/xivo_dao/alchemy/linefeatures.py
+++ b/xivo_dao/alchemy/linefeatures.py
@@ -76,7 +76,6 @@ class LineFeatures(Base):
             ('context',),
             ('context.name',),
             ondelete='CASCADE',
-            onupdate='CASCADE',
         ),
     )
 

--- a/xivo_dao/alchemy/tests/test_extension.py
+++ b/xivo_dao/alchemy/tests/test_extension.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -42,13 +42,6 @@ class TestTenantUUID(DAOTestCase):
 
         assert_that(extension, has_properties(
             tenant_uuid=context.tenant_uuid,
-        ))
-
-    def test_that_if_no_context_then_uuid_is_none(self):
-        extension = self.add_extension()
-
-        assert_that(extension, has_properties(
-            tenant_uuid=None,
         ))
 
 

--- a/xivo_dao/alchemy/user_line.py
+++ b/xivo_dao/alchemy/user_line.py
@@ -17,8 +17,8 @@ class UserLine(Base):
         Index('user_line__idx__line_id', 'line_id'),
     )
 
-    user_id = Column(Integer, ForeignKey('userfeatures.id'), nullable=False)
-    line_id = Column(Integer, ForeignKey('linefeatures.id'), nullable=False)
+    user_id = Column(Integer, ForeignKey('userfeatures.id', ondelete='CASCADE'), nullable=False)
+    line_id = Column(Integer, ForeignKey('linefeatures.id', ondelete='CASCADE'), nullable=False)
     main_user = Column(Boolean, nullable=False)
     main_line = Column(Boolean, nullable=False)
 

--- a/xivo_dao/resources/directory_profile/tests/test_dao.py
+++ b/xivo_dao/resources/directory_profile/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that
@@ -15,7 +15,7 @@ from xivo_dao.tests.test_dao import DAOTestCase
 class TestDirectoryProfileDao(DAOTestCase):
 
     def test_find_by_incall_id(self):
-        user_line = self.add_user_line_with_exten(context='default')
+        user_line = self.add_user_line_with_exten()
         incall = self.add_incall(destination=Dialaction(action='user', actionarg1=user_line.user_id))
         result = profile_dao.find_by_incall_id(incall_id=incall.id)
 

--- a/xivo_dao/resources/endpoint_custom/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_custom/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -211,9 +211,10 @@ class TestDelete(DAOTestCase):
         assert_that(inspect(custom).deleted)
 
     def test_given_line_associated_to_custom_when_deleted_then_line_dissociated(self):
-        custom = self.add_usercustom(context='default')
+        context = self.add_context(name='default')
+        custom = self.add_usercustom(context=context.name)
         line = self.add_line(
-            context='default',
+            context=context.name,
             name='1000',
             number='1000',
             endpoint_custom_id=custom.id,

--- a/xivo_dao/resources/endpoint_sccp/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_sccp/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -250,9 +250,10 @@ class TestDelete(DAOTestCase):
         assert_that(inspect(sccp).deleted)
 
     def test_given_line_associated_to_sccp_when_deleted_then_line_dissociated(self):
-        sccp = self.add_sccpline(context='default', name='1000')
+        context = self.add_context(name='default')
+        sccp = self.add_sccpline(context=context.name, name='1000')
         line = self.add_line(
-            context='default',
+            context=context.name,
             name='1000',
             number='1000',
             endpoint_sccp_id=sccp.id,

--- a/xivo_dao/resources/extension/tests/test_fixes.py
+++ b/xivo_dao/resources/extension/tests/test_fixes.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import assert_that, equal_to
@@ -17,19 +17,22 @@ class TestExtensionFixes(DAOTestCase):
         self.fixes = ExtensionFixes(self.session)
 
     def test_given_extension_associated_to_nothing_then_fixes_pass(self):
-        extension = self.add_extension(exten="1000", context="default")
+        context = self.add_context(name='default')
+        extension = self.add_extension(exten="1000", context=context.name)
         self.fixes.fix(extension.id)
 
     def test_given_extension_associated_to_line_then_number_and_context_updated(self):
-        line = self.add_line(context="mycontext", number="2000")
-        extension = self.add_extension(exten="1000", context="default")
+        mycontext = self.add_context(name='mycontext')
+        default_context = self.add_context(name='default')
+        line = self.add_line(context=mycontext.name, number="2000")
+        extension = self.add_extension(exten="1000", context=default_context.name)
         self.add_line_extension(line_id=line.id, extension_id=extension.id)
 
         self.fixes.fix(extension.id)
 
         line = self.session.query(Line).first()
         assert_that(line.number, equal_to('1000'))
-        assert_that(line.context, equal_to('default'))
+        assert_that(line.context, equal_to(default_context.name))
 
     def test_given_user_has_extension_then_destination_updated(self):
         extension = self.add_extension()

--- a/xivo_dao/resources/line/tests/test_dao.py
+++ b/xivo_dao/resources/line/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -191,10 +191,11 @@ class TestGet(DAOTestCase):
 class TestEdit(DAOTestCase):
 
     def test_edit_all_parameters(self):
+        context = self.add_context(name='mycontext')
         line_row = self.add_line()
 
         line = line_dao.get(line_row.id)
-        line.context = 'mycontext'
+        line.context = context.name
         line.provisioning_code = '234567'
         line.position = 3
         line.registrar = 'otherregistrar'
@@ -206,7 +207,7 @@ class TestEdit(DAOTestCase):
             edited_line,
             has_properties(
                 id=line.id,
-                context='mycontext',
+                context=context.name,
                 provisioning_code='234567',
                 provisioningid=234567,
                 position=3,
@@ -397,7 +398,8 @@ class TestCreate(DAOTestCase):
 
     # The caller ID should only be set once associated to update the endpoint
     def test_when_setting_caller_id_to_null_then_nothing_happens(self):
-        line = Line(context='default', position=1, registrar='default')
+        context = self.add_context(name='default')
+        line = Line(context=context.name, position=1, registrar='default')
         line.caller_id_name = None
         line.caller_id_num = None
 
@@ -447,8 +449,9 @@ class TestDelete(DAOTestCase):
 class TestSearch(DAOTestCase):
 
     def test_search(self):
-        line1 = self.add_line(context='default', provisioningid=123456)
-        self.add_line(context='default', provisioningid=234567)
+        context = self.add_context(name='default')
+        line1 = self.add_line(context=context.name, provisioningid=123456)
+        self.add_line(context=context.name, provisioningid=234567)
 
         search_result = line_dao.search(search='123456')
 
@@ -462,7 +465,8 @@ class TestSearch(DAOTestCase):
 
     def test_search_returns_sip_line_associated(self):
         usersip = self.add_endpoint_sip()
-        line = self.add_line(context='default', endpoint_sip_uuid=usersip.uuid)
+        context = self.add_context(name='default')
+        line = self.add_line(context=context.name, endpoint_sip_uuid=usersip.uuid)
 
         search_result = line_dao.search()
         assert_that(search_result.total, equal_to(1))

--- a/xivo_dao/resources/user_voicemail/tests/test_dao.py
+++ b/xivo_dao/resources/user_voicemail/tests/test_dao.py
@@ -20,14 +20,14 @@ from .. import dao as user_voicemail_dao
 
 class TestUserVoicemail(DAOTestCase):
 
-    def create_user_and_voicemail(self, firstname, exten):
+    def create_user_and_voicemail(self, firstname, exten, context):
         user_row = self.add_user(enablevoicemail=1, firstname=firstname)
-        voicemail_row = self.add_voicemail(mailbox=exten)
+        voicemail_row = self.add_voicemail(mailbox=exten, context=context)
         self.link_user_and_voicemail(user_row, voicemail_row.uniqueid)
         return user_row, voicemail_row
 
-    def prepare_voicemail(self, number):
-        voicemail_row = self.add_voicemail(mailbox=number)
+    def prepare_voicemail(self, number, context):
+        voicemail_row = self.add_voicemail(mailbox=number, context=context)
         return voicemail_row.uniqueid
 
 
@@ -35,7 +35,8 @@ class TestAssociateUserVoicemail(TestUserVoicemail):
 
     def test_associate(self):
         user_row = self.add_user()
-        voicemail_row = self.add_voicemail(mailbox='1000')
+        context = self.add_context(name='default')
+        voicemail_row = self.add_voicemail(mailbox='1000', context=context.name)
 
         user_voicemail_dao.associate(user_row, voicemail_row)
 
@@ -61,12 +62,14 @@ class TestUserVoicemailGetByUserId(TestUserVoicemail):
         self.assertRaises(NotFoundError, user_voicemail_dao.get_by_user_id, user_row.id)
 
     def test_get_by_user_id_with_user_without_voicemail(self):
-        user_line = self.add_user_line_with_exten(firstname='King', exten='1000', context='default')
+        context = self.add_context(name='default')
+        user_line = self.add_user_line_with_exten(firstname='King', exten='1000', context=context.name)
 
         self.assertRaises(NotFoundError, user_voicemail_dao.get_by_user_id, user_line.user.id)
 
     def test_get_by_user_id_with_voicemail(self):
-        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000')
+        context = self.add_context(name='default')
+        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000', context=context.name)
 
         result = user_voicemail_dao.get_by_user_id(user_row.id)
 
@@ -90,14 +93,16 @@ class TestUserVoicemailFindByUserId(TestUserVoicemail):
         assert_that(result, none())
 
     def test_find_by_user_id_with_user_without_voicemail(self):
-        user_line = self.add_user_line_with_exten(firstname='King', exten='1000', context='default')
+        context = self.add_context(name='default')
+        user_line = self.add_user_line_with_exten(firstname='King', exten='1000', context=context.name)
 
         result = user_voicemail_dao.find_by_user_id(user_line.user.id)
 
         assert_that(result, none())
 
     def test_find_by_user_id_with_voicemail(self):
-        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000')
+        context = self.add_context(name='default')
+        user_row, voicemail_row = self.create_user_and_voicemail(firstname='King', exten='1000', context=context.name)
 
         result = user_voicemail_dao.find_by_user_id(user_row.id)
 
@@ -114,7 +119,8 @@ class TestUserVoicemailFindAllByVoicemailId(TestUserVoicemail):
         assert_that(result, contains())
 
     def test_given_voicemail_has_no_user_associated_then_returns_empty_list(self):
-        voicemail_row = self.add_voicemail(mailbox='1000')
+        context = self.add_context(name='default')
+        voicemail_row = self.add_voicemail(mailbox='1000', context=context.name)
 
         result = user_voicemail_dao.find_all_by_voicemail_id(voicemail_row.uniqueid)
 
@@ -148,7 +154,8 @@ class TestUserVoicemailFindAllByVoicemailId(TestUserVoicemail):
 class TestDissociateUserVoicemail(TestUserVoicemail):
 
     def test_dissociate(self):
-        voicemail_row = self.add_voicemail(mailbox='1000')
+        context = self.add_context(name='default')
+        voicemail_row = self.add_voicemail(mailbox='1000', context=context.name)
         user_row = self.add_user(voicemailid=voicemail_row.uniqueid,
                                  enablevoicemail=1)
 
@@ -159,8 +166,9 @@ class TestDissociateUserVoicemail(TestUserVoicemail):
         assert_that(result.enablevoicemail, equal_to(0))
 
     def test_dissociate_not_associated(self):
-        voicemail1 = self.add_voicemail(mailbox='1000')
-        voicemail2 = self.add_voicemail(mailbox='1001')
+        context = self.add_context(name='default')
+        voicemail1 = self.add_voicemail(mailbox='1000', context=context.name)
+        voicemail2 = self.add_voicemail(mailbox='1001', context=context.name)
         user = self.add_user(voicemailid=voicemail1.uniqueid,
                              enablevoicemail=1)
 

--- a/xivo_dao/tests/test_asterisk_conf_dao.py
+++ b/xivo_dao/tests/test_asterisk_conf_dao.py
@@ -88,10 +88,12 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
 
     def test_find_sccp_line_settings_when_line_enabled(self):
         number = '1234'
+        context = self.add_context(name='mycontext')
         sccp_line = self.add_sccpline(cid_num=number)
         ule = self.add_user_line_with_exten(
             endpoint_sccp_id=sccp_line.id,
             exten=number,
+            context=context.name
         )
 
         sccp_lines = asterisk_conf_dao.find_sccp_line_settings()
@@ -103,7 +105,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
                 language=None,
                 number=number,
                 cid_name='Tester One',
-                context='foocontext',
+                context=context.name,
                 cid_num=number,
                 uuid=uuid_()
             )
@@ -122,10 +124,12 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
 
     def test_find_sccp_line_allow(self):
         number = '1234'
-        sccp_line = self.add_sccpline(cid_num=number, allow='g729')
+        context = self.add_context(name='mycontext')
+        sccp_line = self.add_sccpline(cid_num=number, allow='g729', context=context.name)
         ule = self.add_user_line_with_exten(
             endpoint_sccp_id=sccp_line.id,
             exten=number,
+            context=context.name
         )
 
         sccp_lines = asterisk_conf_dao.find_sccp_line_settings()
@@ -137,7 +141,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
                 language=None,
                 number=number,
                 cid_name='Tester One',
-                context='foocontext',
+                context=context.name,
                 cid_num=number,
                 allow='g729',
                 uuid=uuid_(),
@@ -145,11 +149,13 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
         ))
 
     def test_find_sccp_line_disallow(self):
+        context = self.add_context(name='mycontext')
         number = '1234'
-        sccp_line = self.add_sccpline(cid_num=number, allow='g729', disallow='all')
+        sccp_line = self.add_sccpline(cid_num=number, allow='g729', disallow='all', context=context.name)
         ule = self.add_user_line_with_exten(
             endpoint_sccp_id=sccp_line.id,
             exten=number,
+            context=context.name
         )
 
         sccp_lines = asterisk_conf_dao.find_sccp_line_settings()
@@ -161,7 +167,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
                 language=None,
                 number=number,
                 cid_name='Tester One',
-                context='foocontext',
+                context=context.name,
                 cid_num=number,
                 allow='g729',
                 disallow='all',
@@ -171,8 +177,9 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
 
     @patch('xivo_dao.asterisk_conf_dao.find_pickup_members')
     def test_find_sccp_line_pickup_group(self, mock_find_pickup_members):
-        sccp_line = self.add_sccpline()
-        ule = self.add_user_line_with_exten(endpoint_sccp_id=sccp_line.id)
+        context = self.add_context(name='mycontext')
+        sccp_line = self.add_sccpline(context=context.name)
+        ule = self.add_user_line_with_exten(endpoint_sccp_id=sccp_line.id, context=context.name)
         callgroups = {1, 2, 3, 4}
         pickupgroups = {3, 4}
         pickup_members = {
@@ -189,7 +196,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
                 language=None,
                 number=ule.extension.exten,
                 cid_name='Tester One',
-                context='foocontext',
+                context=context.name,
                 cid_num=sccp_line.cid_num,
                 callgroup=callgroups,
                 pickupgroup=pickupgroups,
@@ -233,7 +240,8 @@ class TestSccpConfDAO(DAOTestCase):
         ))
 
     def test_find_sccp_device_settings(self):
-        extension = self.add_extension(exten='1000', context='default')
+        context = self.add_context(name='default')
+        extension = self.add_extension(exten='1000', context=context.name)
         sccp_device = self.add_sccpdevice(line=extension.exten)
         sccp_line = self.add_sccpline(name=extension.exten, context=extension.context)
         line = self.add_line(endpoint_sccp_id=sccp_line.id, context=extension.context)
@@ -264,9 +272,9 @@ class TestFindSccpSpeeddialSettings(DAOTestCase):
     def test_given_custom_func_key_then_returns_converted_func_key(self):
         exten = '1000'
         func_key_exten = '2000'
-        context = 'default'
+        context = self.add_context(name='default')
 
-        user_row, sccp_device_row = self.add_user_with_sccp_device(exten=exten, context=context)
+        user_row, sccp_device_row = self.add_user_with_sccp_device(exten=exten, context=context.name)
         func_key_mapping_row = self.add_custom_func_key_to_user(user_row, func_key_exten)
 
         result = asterisk_conf_dao.find_sccp_speeddial_settings()
@@ -285,10 +293,10 @@ class TestFindSccpSpeeddialSettings(DAOTestCase):
     def test_given_func_key_with_invalid_characters_then_characters_are_escaped(self):
         exten = '1000'
         func_key_exten = '\n2;0\t0\r0'
-        context = 'default'
+        context = self.add_context(name='default')
         label = '\nhe;l\tlo\r'
 
-        user_row, sccp_device_row = self.add_user_with_sccp_device(exten=exten, context=context)
+        user_row, sccp_device_row = self.add_user_with_sccp_device(exten=exten, context=context.name)
         self.add_custom_func_key_to_user(user_row, func_key_exten, label=label)
 
         result = asterisk_conf_dao.find_sccp_speeddial_settings()
@@ -1279,9 +1287,10 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         )
 
     def test_that_doubles_are_removed(self):
+        context = self.add_context(name='wazo-meeting-uuid-guest')
         template = self.add_endpoint_sip(
             template=True,
-            endpoint_section_options=[['webrtc', 'true'], ['context', 'wazo-meeting-uuid-guest']]
+            endpoint_section_options=[['webrtc', 'true'], ['context', context.name]]
         )
         endpoint = self.add_endpoint_sip(
             templates=[template],
@@ -1306,7 +1315,7 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
                         contains('set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'),
                         contains('set_var', f'WAZO_MEETING_UUID={meeting.uuid}'),
                         contains('set_var', f'WAZO_MEETING_NAME={meeting.name}'),
-                        contains('context', 'wazo-meeting-uuid-guest'),
+                        contains('context', context.name),
                     )
                 )
             )
@@ -1756,7 +1765,8 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
                 ['webrtc', 'true'],
             ]
         )
-        line = self.add_line(endpoint_sip_uuid=endpoint.uuid)
+        context = self.add_context(name='mycontext')
+        line = self.add_line(endpoint_sip_uuid=endpoint.uuid, context=context.name)
 
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
@@ -1770,8 +1780,8 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
                         contains('set_var', f'__WAZO_TENANT_UUID={endpoint.tenant_uuid}'),
                         contains('set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'),
                         contains('set_var', f'WAZO_LINE_ID={line.id}'),
-                        contains('context', 'foocontext'),
-                        contains('set_var', 'TRANSFER_CONTEXT=foocontext')
+                        contains('context', context.name),
+                        contains('set_var', f'TRANSFER_CONTEXT={context.name}')
                     )
                 )
             )

--- a/xivo_dao/tests/test_callfilter_dao.py
+++ b/xivo_dao/tests/test_callfilter_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao import callfilter_dao
@@ -31,42 +31,42 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
         self.assertEqual(result, [])
 
     def test_given_boss_then_returns_empty_list(self):
-        context = 'mycontext'
+        context = self.add_context(name='mycontext')
         call_filter = self.add_call_filter()
-        self._create_user_and_add_to_filter(call_filter.id, 'boss', context)
+        self._create_user_and_add_to_filter(call_filter.id, 'boss', context.name)
 
-        result = callfilter_dao.get_secretaries_id_by_context(context)
+        result = callfilter_dao.get_secretaries_id_by_context(context.name)
 
         self.assertEqual(result, [])
 
     def test_given_one_secretary_then_returns_list_with_id(self):
-        context = 'mycontext'
+        context = self.add_context(name='mycontext')
         call_filter = self.add_call_filter()
-        member = self._create_user_and_add_to_filter(call_filter.id, 'secretary', context)
+        member = self._create_user_and_add_to_filter(call_filter.id, 'secretary', context.name)
 
-        result = callfilter_dao.get_secretaries_id_by_context(context)
+        result = callfilter_dao.get_secretaries_id_by_context(context.name)
 
         self.assertEqual(len(result), 1)
         self.assertIn((member.id,), result)
 
     def test_given_two_secretaries_then_returns_list_with_both_ids(self):
-        context = 'mycontext'
+        context = self.add_context(name='mycontext')
         call_filter = self.add_call_filter()
-        first_member = self._create_user_and_add_to_filter(call_filter.id, 'secretary', context)
-        second_member = self._create_user_and_add_to_filter(call_filter.id, 'secretary', context)
+        first_member = self._create_user_and_add_to_filter(call_filter.id, 'secretary', context.name)
+        second_member = self._create_user_and_add_to_filter(call_filter.id, 'secretary', context.name)
 
-        result = callfilter_dao.get_secretaries_id_by_context(context)
+        result = callfilter_dao.get_secretaries_id_by_context(context.name)
 
         self.assertEqual(len(result), 2)
         self.assertIn((first_member.id,), result)
         self.assertIn((second_member.id,), result)
 
     def test_given_line_with_multiple_users_then_returns_list_with_one_id(self):
-        context = 'mycontext'
+        context = self.add_context(name='mycontext')
         call_filter = self.add_call_filter()
-        extension = self.add_extension(context=context)
+        extension = self.add_extension(context=context.name)
 
-        line = self.add_line(context=context)
+        line = self.add_line(context=context.name)
         main_user = self.add_user()
         secondary_user = self.add_user()
 
@@ -83,18 +83,18 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
 
         member = self._add_user_to_filter(main_user.id, call_filter.id, 'secretary')
 
-        result = callfilter_dao.get_secretaries_id_by_context(context)
+        result = callfilter_dao.get_secretaries_id_by_context(context.name)
 
         self.assertEqual(len(result), 1)
         self.assertIn((member.id,), result)
 
     def test_given_user_with_multiple_line_then_returns_list_with_one_id(self):
-        context = 'mycontext'
+        context = self.add_context(name='mycontext')
         call_filter = self.add_call_filter()
-        extension = self.add_extension(context=context)
+        extension = self.add_extension(context=context.name)
 
-        main_line = self.add_line(context=context)
-        secondary_line = self.add_line(context=context)
+        main_line = self.add_line(context=context.name)
+        secondary_line = self.add_line(context=context.name)
         user = self.add_user()
 
         self.add_user_line(user_id=user.id,
@@ -112,7 +112,7 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
 
         member = self._add_user_to_filter(user.id, call_filter.id, 'secretary')
 
-        result = callfilter_dao.get_secretaries_id_by_context(context)
+        result = callfilter_dao.get_secretaries_id_by_context(context.name)
 
         self.assertEqual(len(result), 1)
         self.assertIn((member.id,), result)

--- a/xivo_dao/tests/test_dao.py
+++ b/xivo_dao/tests/test_dao.py
@@ -144,7 +144,6 @@ class ItemInserter:
         kwargs.setdefault('email', None)
         kwargs.setdefault('callerid', f'"{kwargs["firstname"]} {kwargs["lastname"]}"')
         kwargs.setdefault('exten', f'{random.randint(1000, 1999)}')
-        kwargs.setdefault('context', 'foocontext')
         kwargs.setdefault('name_line', ''.join(random.choice('0123456789ABCDEF') for _ in range(6)))
         kwargs.setdefault('commented_line', 0)
         kwargs.setdefault('device', 1)
@@ -158,6 +157,9 @@ class ItemInserter:
         kwargs.setdefault('endpoint_sccp_id', None)
         kwargs.setdefault('endpoint_custom_id', None)
         kwargs.setdefault('tenant_uuid', self.default_tenant.uuid)
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
 
         user = self.add_user(firstname=kwargs['firstname'],
                              lastname=kwargs['lastname'],
@@ -195,7 +197,6 @@ class ItemInserter:
         kwargs.setdefault('firstname', 'unittest')
         kwargs.setdefault('lastname', 'unittest')
         kwargs.setdefault('callerid', f'"{kwargs["firstname"]} {kwargs["lastname"]}"')
-        kwargs.setdefault('context', 'foocontext')
         kwargs.setdefault('name_line', ''.join(random.choice('0123456789ABCDEF') for _ in range(6)))
         kwargs.setdefault('commented_line', 0)
         kwargs.setdefault('device', 1)
@@ -206,6 +207,9 @@ class ItemInserter:
         kwargs.setdefault('description', '')
         kwargs.setdefault('userfield', '')
         kwargs.setdefault('endpoint_sip_uuid', None)
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
 
         user = self.add_user(firstname=kwargs['firstname'],
                              lastname=kwargs['lastname'],
@@ -236,13 +240,15 @@ class ItemInserter:
         kwargs.setdefault('firstname', 'unittest')
         kwargs.setdefault('lastname', 'unittest')
         kwargs.setdefault('callerid', f'"{kwargs["firstname"]} {kwargs["lastname"]}"')
-        kwargs.setdefault('context', 'foocontext')
         kwargs.setdefault('name_line', ''.join(random.choice('0123456789ABCDEF') for _ in range(6)))
         kwargs.setdefault('commented_line', 0)
         kwargs.setdefault('device', 1)
         kwargs.setdefault('voicemail_id', None)
         kwargs.setdefault('agentid', None)
         kwargs.setdefault('mobilephonenumber', '+14184765458')
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
 
         user = self.add_user(firstname=kwargs['firstname'],
                              lastname=kwargs['lastname'],
@@ -295,8 +301,10 @@ class ItemInserter:
 
     def add_line(self, **kwargs):
         kwargs.setdefault('name', self._random_name())
-        kwargs.setdefault('context', 'foocontext')
         kwargs.setdefault('provisioningid', int(''.join(random.choice('123456789') for _ in range(6))))
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
 
         line = LineFeatures(**kwargs)
         self.add_me(line)
@@ -395,7 +403,9 @@ class ItemInserter:
     def add_extension(self, **kwargs):
         kwargs.setdefault('exten', f'{self._generate_random_exten()}')
         kwargs.setdefault('type', 'user')
-        kwargs.setdefault('context', 'default')
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
 
         extension = Extension(**kwargs)
         self.add_me(extension)
@@ -697,10 +707,12 @@ class ItemInserter:
 
     def add_sccpline(self, **kwargs):
         kwargs.setdefault('name', ''.join(random.choice('0123456789ABCDEF') for _ in range(6)))
-        kwargs.setdefault('context', 'default')
         kwargs.setdefault('cid_name', 'Tester One')
         kwargs.setdefault('cid_num', '1234')
         kwargs.setdefault('tenant_uuid', self.default_tenant.uuid)
+        if not kwargs.get('context'):
+            context = self.add_context()
+            kwargs['context'] = context.name
 
         sccpline = SCCPLine(**kwargs)
         self.add_me(sccpline)


### PR DESCRIPTION
When a user is deleted, related line(s) must be disassociated
When a line is deleted, related user(s) must be disassociated
When context deleted, related lines must be deleted
Depends-On: https://github.com/wazo-platform/xivo-manage-db/pull/206