### PR TITLE
zuul: fix debug step to show DB container URL

### DIFF
--- a/zuul.d/roles/xivo-dao-db/tasks/main.yml
+++ b/zuul.d/roles/xivo-dao-db/tasks/main.yml
@@ -8,10 +8,10 @@
   register: container_port
   args:
     chdir: "{{ zuul.project.src_dir }}"
-- name: Show DB container URL
-  debug:
-    var: tox_environment
 - name: Export DB container port
   set_fact:
     tox_environment:
       XIVO_TEST_DB_URL: "postgresql://asterisk:proformatique@{{ container_port.stdout }}/asterisk"
+- name: Show DB container URL
+  debug:
+    var: tox_environment


### PR DESCRIPTION
why: to see the variable, we must set it before ...