### PR TITLE
incall: avoid searching through ID fields

### DIFF
--- a/xivo_dao/alchemy/incall.py
+++ b/xivo_dao/alchemy/incall.py
@@ -123,20 +123,6 @@ class Incall(Base):
         self.dialaction.actionarg2 = destination.actionarg2
 
     @hybrid_property
-    def user_id(self):
-        if self.dialaction and self.dialaction.action == 'user':
-            return int(self.dialaction.actionarg1)
-        return None
-
-    @user_id.expression
-    def user_id(cls):
-        return (select([cast(Dialaction.actionarg1, Integer)])
-                .where(Dialaction.action == 'user')
-                .where(Dialaction.category == 'incall')
-                .where(Dialaction.categoryval == cast(cls.id, String))
-                .as_scalar())
-
-    @hybrid_property
     def exten(self):
         for extension in self.extensions:
             return extension.exten

--- a/xivo_dao/resources/incall/search.py
+++ b/xivo_dao/resources/incall/search.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.incall import Incall
@@ -8,14 +8,12 @@ from xivo_dao.resources.utils.search import SearchSystem, SearchConfig
 config = SearchConfig(
     table=Incall,
     columns={
-        'id': Incall.id,
         'preprocess_subroutine': Incall.preprocess_subroutine,
         'greeting_sound': Incall.greeting_sound,
-        'user_id': Incall.user_id,
         'description': Incall.description,
         'exten': Incall.exten,
     },
-    default_sort='id',
+    default_sort='exten',
 )
 
 incall_search = SearchSystem(config)

--- a/xivo_dao/resources/incall/tests/test_dao.py
+++ b/xivo_dao/resources/incall/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -105,14 +105,6 @@ class TestFindBy(DAOTestCase):
         assert_that(incall, equal_to(incall_row))
         assert_that(incall.description, equal_to('mydescription'))
 
-    def test_find_by_user_id(self):
-        incall_row = self.add_incall(destination=Dialaction(action='user', actionarg1='2'))
-
-        incall = incall_dao.find_by(user_id=2)
-
-        assert_that(incall, equal_to(incall_row))
-        assert_that(incall.user_id, equal_to(2))
-
     def test_given_incall_does_not_exist_then_returns_null(self):
         incall = incall_dao.find_by(id=42)
 
@@ -161,14 +153,6 @@ class TestGetBy(DAOTestCase):
         assert_that(incall, equal_to(incall_row))
         assert_that(incall.description, equal_to('mydescription'))
 
-    def test_get_by_user_id(self):
-        incall_row = self.add_incall(destination=Dialaction(action='user', actionarg1='2'))
-
-        incall = incall_dao.get_by(user_id=2)
-
-        assert_that(incall, equal_to(incall_row))
-        assert_that(incall.user_id, equal_to(2))
-
     def test_given_incall_does_not_exist_then_raises_error(self):
         self.assertRaises(NotFoundError, incall_dao.get_by, id='42')
 
@@ -195,11 +179,11 @@ class TestFindAllBy(DAOTestCase):
         assert_that(result, contains())
 
     def test_find_all_by_custom_column(self):
-        incall1 = self.add_incall(destination=Dialaction(action='user', actionarg1='2'))
-        incall2 = self.add_incall(destination=Dialaction(action='user', actionarg1='2'))
+        incall1 = self.add_incall(preprocess_subroutine='mysub', destination=Dialaction(action='user', actionarg1='2'))
+        incall2 = self.add_incall(preprocess_subroutine='mysub', destination=Dialaction(action='user', actionarg1='2'))
         self.add_incall(destination=Dialaction(action='user', actionarg1='3'))
 
-        incalls = incall_dao.find_all_by(user_id=2)
+        incalls = incall_dao.find_all_by(preprocess_subroutine='mysub')
 
         assert_that(
             incalls, has_items(has_property('id', incall1.id), has_property('id', incall2.id)),


### PR DESCRIPTION
the user does not know the incall id or the user id. Allowing this only leads to poor user experience when searching for 1001 and ending up with 3 results

incall exten 1001
incall id 1001
incall with a user destination with id 1001

Also searching in user_id is very expensive at the moment