### PR TITLE
user: move load strategy to the strategy module

### DIFF
--- a/xivo_dao/resources/user/dao.py
+++ b/xivo_dao/resources/user/dao.py
@@ -1,6 +1,7 @@
 # Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from contextlib import contextmanager
 
 from xivo_dao.helpers.db_manager import Session
 
@@ -80,3 +81,9 @@ def delete(user):
 
 def associate_all_groups(user, groups):
     persistor().associate_all_groups(user, groups)
+
+
+@contextmanager
+def query_options(*options):
+    with UserPersistor.context_query_options(*options):
+        yield

--- a/xivo_dao/resources/user/persistor.py
+++ b/xivo_dao/resources/user/persistor.py
@@ -9,10 +9,11 @@ from xivo_dao.helpers.db_manager import Session
 
 from xivo_dao.helpers import errors
 from xivo_dao.helpers.persistor import BasePersistor
+from xivo_dao.resources.utils.query_options import QueryOptionsMixin
 from xivo_dao.resources.utils.search import SearchResult, CriteriaBuilderMixin
 
 
-class UserPersistor(CriteriaBuilderMixin, BasePersistor):
+class UserPersistor(QueryOptionsMixin, CriteriaBuilderMixin, BasePersistor):
     _search_table = User
 
     def __init__(self, session, user_view, user_search, tenant_uuids=None):
@@ -58,7 +59,10 @@ class UserPersistor(CriteriaBuilderMixin, BasePersistor):
         return query.all()
 
     def _search(self, parameters, is_collated=False):
-        view = self.user_view.select(parameters.get('view'))
+        view = self.user_view.select(
+            parameters.get('view'),
+            default_query=self._generate_query(),
+        )
         query = view.query(self.session)
         if self.tenant_uuids is not None:
             query = query.filter(User.tenant_uuid.in_(self.tenant_uuids))

--- a/xivo_dao/resources/user/strategy.py
+++ b/xivo_dao/resources/user/strategy.py
@@ -1,0 +1,53 @@
+# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from sqlalchemy.orm import joinedload, selectinload, lazyload
+
+
+user_unpaginated_strategy = (
+    joinedload('agent'),
+    joinedload('rightcall_members').selectinload('rightcall'),
+    joinedload('group_members')
+    .selectinload('group')
+    .selectinload('call_pickup_interceptor_pickups')
+    .options(
+        selectinload('pickupmember_user_targets').selectinload('user'),
+        selectinload('pickupmember_group_targets')
+        .selectinload('group')
+        .selectinload('user_queue_members')
+        .selectinload('user'),
+    ),
+    joinedload('call_pickup_interceptor_pickups').options(
+        selectinload('pickupmember_user_targets').selectinload('user'),
+        selectinload('pickupmember_group_targets')
+        .selectinload('group')
+        .selectinload('user_queue_members')
+        .selectinload('user'),
+    ),
+    joinedload('user_dialactions').selectinload('user'),
+    joinedload('incall_dialactions')
+    .selectinload('incall')
+    .selectinload('extensions'),
+    joinedload('user_lines').options(
+        selectinload('line').options(
+            selectinload('application'),
+            selectinload('context_rel'),
+            selectinload('endpoint_sip').options(
+                selectinload('_endpoint_section').selectinload('_options'),
+                selectinload('_auth_section').selectinload('_options'),
+            ),
+            selectinload('endpoint_sccp'),
+            selectinload('endpoint_custom'),
+            selectinload('line_extensions').selectinload('extension'),
+            selectinload('user_lines').selectinload('user'),
+        ),
+    ),
+    joinedload('queue_members'),
+    joinedload('schedule_paths').selectinload('schedule'),
+    joinedload('switchboard_member_users').selectinload('switchboard'),
+    joinedload('voicemail'),
+    lazyload('*'),
+)
+
+
+no_strategy = []


### PR DESCRIPTION
the configured strategy is now used when no view is specified

When a view is configured the strategy is ignored because we are using a custom query instead of the typical "session.query(User)" that is compatible with the strategies