### PR TITLE
Pull request for pytest-warnings

### DIFF
--- a/xivo_dao/alchemy/tests/test_asterisk_file.py
+++ b/xivo_dao/alchemy/tests/test_asterisk_file.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_entries,
     none,
@@ -27,7 +27,7 @@ class TestSectionsOrdered(DAOTestCase):
         result = self.session.query(AsteriskFile).filter_by(id=file_.id).first()
 
         assert_that(result, equal_to(file_))
-        assert_that(result.sections_ordered, contains(
+        assert_that(result.sections_ordered, contains_exactly(
             file_section2,
             file_section1,
             file_section3,

--- a/xivo_dao/alchemy/tests/test_asterisk_file_section.py
+++ b/xivo_dao/alchemy/tests/test_asterisk_file_section.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     none,
 )
@@ -27,7 +27,7 @@ class TestVariables(DAOTestCase):
         result = self.session.query(AsteriskFileSection).filter_by(id=file_section.id).first()
 
         assert_that(result, equal_to(file_section))
-        assert_that(result.variables, contains(
+        assert_that(result.variables, contains_exactly(
             file_variable2,
             file_variable1,
             file_variable3,

--- a/xivo_dao/alchemy/tests/test_callfilter.py
+++ b/xivo_dao/alchemy/tests/test_callfilter.py
@@ -1,11 +1,11 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     empty,
     has_properties,
@@ -153,7 +153,7 @@ class TestRecipients(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(call_filter.recipients, contains(recipient))
+        assert_that(call_filter.recipients, contains_exactly(recipient))
 
     def test_associate_order_by(self):
         call_filter = self.add_call_filter()
@@ -165,7 +165,7 @@ class TestRecipients(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(call_filter.recipients, contains(recipient2, recipient3, recipient1))
+        assert_that(call_filter.recipients, contains_exactly(recipient2, recipient3, recipient1))
 
     def test_dissociate(self):
         call_filter = self.add_call_filter()
@@ -195,7 +195,7 @@ class TestSurrogates(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(call_filter.surrogates, contains(surrogate))
+        assert_that(call_filter.surrogates, contains_exactly(surrogate))
 
     def test_associate_order_by(self):
         call_filter = self.add_call_filter()
@@ -207,7 +207,7 @@ class TestSurrogates(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(call_filter.surrogates, contains(surrogate2, surrogate3, surrogate1))
+        assert_that(call_filter.surrogates, contains_exactly(surrogate2, surrogate3, surrogate1))
 
     def test_dissociate(self):
         call_filter = self.add_call_filter()

--- a/xivo_dao/alchemy/tests/test_context.py
+++ b/xivo_dao/alchemy/tests/test_context.py
@@ -1,9 +1,9 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     has_properties,
@@ -28,7 +28,7 @@ class TestContexts(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(context.contexts, contains(has_properties(name='included_context')))
+        assert_that(context.contexts, contains_exactly(has_properties(name='included_context')))
 
     def test_associate_order_by(self):
         context = self.add_context()
@@ -40,7 +40,7 @@ class TestContexts(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(context.contexts, contains(
+        assert_that(context.contexts, contains_exactly(
             included_context2,
             included_context3,
             included_context1,

--- a/xivo_dao/alchemy/tests/test_endpoint_sip.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip.py
@@ -1,9 +1,9 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -55,7 +55,7 @@ class TestEndpointSIP(DAOTestCase):
             outbound_auth_section_options=[['type', 'auth']],
             template=True,
             transport=has_properties(uuid=transport.uuid),
-            templates=contains(
+            templates=contains_exactly(
                 has_properties(uuid=template_1.uuid),
                 has_properties(uuid=template_2.uuid),
             ),
@@ -97,7 +97,7 @@ class TestEndpointSIP(DAOTestCase):
             outbound_auth_section_options=[],
             template=False,
             transport_uuid=None,
-            templates=contains(
+            templates=contains_exactly(
                 has_properties(uuid=template.uuid),
             )
         ))
@@ -197,7 +197,7 @@ class TestTemplates(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(sip.templates, contains(
+        assert_that(sip.templates, contains_exactly(
             template_2,
             template_3,
             template_1,
@@ -253,7 +253,7 @@ class TestInheritedOptions(DAOTestCase):
 
         assert_that(
             sip.inherited_aor_section_options,
-            contains(
+            contains_exactly(
                 # template_1 options
                 ['max_contacts', '1'],
                 ['remove_existing', 'yes'],
@@ -279,7 +279,7 @@ class TestInheritedOptions(DAOTestCase):
 
         assert_that(
             sip.inherited_endpoint_section_options,
-            contains(
+            contains_exactly(
                 # template_1 options
                 ['webrtc', 'yes'],
                 ['allow', '!all,ulaw'],
@@ -310,7 +310,7 @@ class TestCombinedOptions(DAOTestCase):
 
         assert_that(
             sip.combined_aor_section_options,
-            contains(
+            contains_exactly(
                 # template_1 options
                 ['max_contacts', '1'],
                 ['remove_existing', 'yes'],
@@ -342,7 +342,7 @@ class TestCombinedOptions(DAOTestCase):
 
         assert_that(
             sip.combined_endpoint_section_options,
-            contains(
+            contains_exactly(
                 # template_1 options
                 ['webrtc', 'yes'],
                 ['allow', '!all,ulaw'],

--- a/xivo_dao/alchemy/tests/test_groupfeatures.py
+++ b/xivo_dao/alchemy/tests/test_groupfeatures.py
@@ -1,9 +1,9 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -157,7 +157,7 @@ class TestSchedules(DAOTestCase):
 
         row = self.session.query(Group).filter_by(id=group.id).first()
         assert_that(row, equal_to(group))
-        assert_that(row.schedules, contains(schedule))
+        assert_that(row.schedules, contains_exactly(schedule))
 
     def test_setter(self):
         group = self.add_group()
@@ -199,7 +199,7 @@ class TestUserQueueMembers(DAOTestCase):
         queue_member2 = self.add_queue_member(category='group', usertype='user', queue_name=group.name, position=2)
 
         self.session.expire_all()
-        assert_that(group.user_queue_members, contains(queue_member1, queue_member2))
+        assert_that(group.user_queue_members, contains_exactly(queue_member1, queue_member2))
 
     def test_getter_when_extension_member(self):
         group = self.add_group()
@@ -212,7 +212,7 @@ class TestUserQueueMembers(DAOTestCase):
         )
 
         self.session.expire_all()
-        assert_that(group.user_queue_members, contains(queue_member))
+        assert_that(group.user_queue_members, contains_exactly(queue_member))
 
     def test_setter(self):
         group = self.add_group()
@@ -221,7 +221,7 @@ class TestUserQueueMembers(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(group.user_queue_members, contains(queue_member))
+        assert_that(group.user_queue_members, contains_exactly(queue_member))
         assert_that(queue_member.queue_name, equal_to(group.name))
 
     def test_deleter(self):
@@ -267,7 +267,7 @@ class TestExtensionQueueMembers(DAOTestCase):
         )
 
         self.session.expire_all()
-        assert_that(group.extension_queue_members, contains(queue_member1, queue_member2))
+        assert_that(group.extension_queue_members, contains_exactly(queue_member1, queue_member2))
 
     def test_getter_when_user_member(self):
         group = self.add_group()
@@ -280,7 +280,7 @@ class TestExtensionQueueMembers(DAOTestCase):
         self.add_queue_member(category='group', usertype='user', queue_name=group.name, position=1)
 
         self.session.expire_all()
-        assert_that(group.extension_queue_members, contains(queue_member))
+        assert_that(group.extension_queue_members, contains_exactly(queue_member))
 
     def test_setter(self):
         group = self.add_group()
@@ -289,7 +289,7 @@ class TestExtensionQueueMembers(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(group.extension_queue_members, contains(queue_member))
+        assert_that(group.extension_queue_members, contains_exactly(queue_member))
         assert_that(queue_member.queue_name, equal_to(group.name))
 
     def test_deleter(self):
@@ -527,7 +527,7 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         )
 
         assert_that(
-            group_interceptor.call_pickup_interceptor_pickups, contains(call_pickup)
+            group_interceptor.call_pickup_interceptor_pickups, contains_exactly(call_pickup)
         )
 
     def test_two_pickups_two_user_targets(self):
@@ -547,20 +547,20 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             group_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup1, call_pickup2),
+            contains_exactly(call_pickup1, call_pickup2),
         )
 
         assert_that(
             group_interceptor.users_from_call_pickup_user_targets,
-            contains(
-                contains(user_target1),
-                contains(user_target2),
+            contains_exactly(
+                contains_exactly(user_target1),
+                contains_exactly(user_target2),
             ),
         )
 
         assert_that(
             group_interceptor.users_from_call_pickup_group_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
 
     # Groups
@@ -591,17 +591,17 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             group_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup),
+            contains_exactly(call_pickup),
         )
 
         assert_that(
             group_interceptor.users_from_call_pickup_user_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
 
         assert_that(
             group_interceptor.users_from_call_pickup_group_targets,
-            contains(contains(contains(user_target1), contains(user_target2))),
+            contains_exactly(contains_exactly(contains_exactly(user_target1), contains_exactly(user_target2))),
         )
 
     def test_two_pickups_two_group_targets(self):
@@ -634,17 +634,17 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             group_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup1, call_pickup2),
+            contains_exactly(call_pickup1, call_pickup2),
         )
 
         assert_that(
             group_interceptor.users_from_call_pickup_user_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
 
         assert_that(
             group_interceptor.users_from_call_pickup_group_targets,
-            contains(contains(contains(user_target1)), contains(contains(user_target2))),
+            contains_exactly(contains_exactly(contains_exactly(user_target1)), contains_exactly(contains_exactly(user_target2))),
         )
 
 
@@ -675,11 +675,11 @@ class TestUsersFromCallPickupUserTargets(DAOTestCase):
 
         assert_that(
             group_interceptor.users_from_call_pickup_user_targets,
-            contains(contains(user_target1, user_target2)),
+            contains_exactly(contains_exactly(user_target1, user_target2)),
         )
         assert_that(
             group_interceptor.users_from_call_pickup_group_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
 
     def test_two_pickups_two_user_targets(self):
@@ -715,11 +715,11 @@ class TestUsersFromCallPickupUserTargets(DAOTestCase):
 
         assert_that(
             group_interceptor.users_from_call_pickup_user_targets,
-            contains(contains(user_target1), contains(user_target2)),
+            contains_exactly(contains_exactly(user_target1), contains_exactly(user_target2)),
         )
         assert_that(
             group_interceptor.users_from_call_pickup_group_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
 
 
@@ -764,11 +764,11 @@ class TestUsersFromCallPickupGroupTargets(DAOTestCase):
 
         assert_that(
             group_interceptor.users_from_call_pickup_user_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
         assert_that(
             group_interceptor.users_from_call_pickup_group_targets,
-            contains(contains(contains(user_target1), contains(user_target2))),
+            contains_exactly(contains_exactly(contains_exactly(user_target1), contains_exactly(user_target2))),
         )
 
     def test_two_pickups_two_user_targets(self):
@@ -818,12 +818,12 @@ class TestUsersFromCallPickupGroupTargets(DAOTestCase):
 
         assert_that(
             group_interceptor.users_from_call_pickup_user_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
         assert_that(
             group_interceptor.users_from_call_pickup_group_targets,
-            contains(
-                contains(contains(user_target1)),
-                contains(contains(user_target2)),
+            contains_exactly(
+                contains_exactly(contains_exactly(user_target1)),
+                contains_exactly(contains_exactly(user_target2)),
             ),
         )

--- a/xivo_dao/alchemy/tests/test_incall.py
+++ b/xivo_dao/alchemy/tests/test_incall.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -27,7 +27,7 @@ class TestSchedules(DAOTestCase):
 
         row = self.session.query(Incall).filter_by(id=incall.id).first()
         assert_that(row, equal_to(incall))
-        assert_that(row.schedules, contains(schedule))
+        assert_that(row.schedules, contains_exactly(schedule))
 
     def test_setter(self):
         incall = self.add_incall()

--- a/xivo_dao/alchemy/tests/test_outcall.py
+++ b/xivo_dao/alchemy/tests/test_outcall.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -34,7 +34,7 @@ class TestSchedules(DAOTestCase):
 
         row = self.session.query(Outcall).filter_by(id=outcall.id).first()
         assert_that(row, equal_to(outcall))
-        assert_that(row.schedules, contains(schedule))
+        assert_that(row.schedules, contains_exactly(schedule))
 
     def test_setter(self):
         outcall = self.add_outcall()
@@ -128,7 +128,7 @@ class TestTrunks(DAOTestCase):
 
         outcall = self.session.query(Outcall).filter_by(id=outcall_row.id).first()
         assert_that(outcall, equal_to(outcall_row))
-        assert_that(outcall.trunks, contains(trunk2_row, trunk3_row, trunk1_row))
+        assert_that(outcall.trunks, contains_exactly(trunk2_row, trunk3_row, trunk1_row))
 
     def test_trunks_dissociate(self):
         outcall_row = self.add_outcall()
@@ -261,10 +261,10 @@ class TestUpdateExtensionAssociation(DAOTestCase):
                                                  external_prefix='123')
 
         rows = self.session.query(Extension).all()
-        assert_that(rows, contains(extension_row))
+        assert_that(rows, contains_exactly(extension_row))
 
         rows = self.session.query(DialPattern).all()
-        assert_that(rows, contains(has_properties(
+        assert_that(rows, contains_exactly(has_properties(
             caller_id='tata',
             external_prefix='123',
             prefix='1',

--- a/xivo_dao/alchemy/tests/test_paging.py
+++ b/xivo_dao/alchemy/tests/test_paging.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from hamcrest import (assert_that,
-                      contains,
+                      contains_exactly,
                       contains_inanyorder,
                       empty,
                       equal_to,
@@ -29,7 +29,7 @@ class TestUsersMember(DAOTestCase):
 
         row = self.session.query(Paging).filter_by(id=paging.id).first()
         assert_that(row, equal_to(paging))
-        assert_that(row.users_member, contains(user))
+        assert_that(row.users_member, contains_exactly(user))
 
     def test_setter(self):
         paging = self.add_paging()
@@ -72,7 +72,7 @@ class TestUsersCaller(DAOTestCase):
 
         row = self.session.query(Paging).filter_by(id=paging.id).first()
         assert_that(row, equal_to(paging))
-        assert_that(row.users_caller, contains(user))
+        assert_that(row.users_caller, contains_exactly(user))
 
     def test_setter(self):
         paging = self.add_paging()

--- a/xivo_dao/alchemy/tests/test_pickup.py
+++ b/xivo_dao/alchemy/tests/test_pickup.py
@@ -1,11 +1,11 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     empty,
     none,
@@ -46,7 +46,7 @@ class TestPickupmemberUserTargets(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.pickupmember_user_targets, contains(target))
+        assert_that(pickup.pickupmember_user_targets, contains_exactly(target))
 
     def test_dissociate(self):
         pickup = self.add_pickup()
@@ -76,7 +76,7 @@ class TestPickupmemberUserInterceptors(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.pickupmember_user_interceptors, contains(interceptor))
+        assert_that(pickup.pickupmember_user_interceptors, contains_exactly(interceptor))
 
     def test_dissociate(self):
         pickup = self.add_pickup()
@@ -106,7 +106,7 @@ class TestPickupmemberGroupTargets(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.pickupmember_group_targets, contains(target))
+        assert_that(pickup.pickupmember_group_targets, contains_exactly(target))
 
     def test_dissociate(self):
         pickup = self.add_pickup()
@@ -136,7 +136,7 @@ class TestPickupmemberGroupInterceptors(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.pickupmember_group_interceptors, contains(interceptor))
+        assert_that(pickup.pickupmember_group_interceptors, contains_exactly(interceptor))
 
     def test_dissociate(self):
         pickup = self.add_pickup()
@@ -175,7 +175,7 @@ class TestUserInterceptors(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.user_interceptors, contains(user))
+        assert_that(pickup.user_interceptors, contains_exactly(user))
 
     def test_delete(self):
         pickup = self.add_pickup()
@@ -209,7 +209,7 @@ class TestGroupInterceptors(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.group_interceptors, contains(group))
+        assert_that(pickup.group_interceptors, contains_exactly(group))
 
     def test_delete(self):
         pickup = self.add_pickup()
@@ -243,7 +243,7 @@ class TestUserTargets(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.user_targets, contains(user))
+        assert_that(pickup.user_targets, contains_exactly(user))
 
     def test_delete(self):
         pickup = self.add_pickup()
@@ -277,7 +277,7 @@ class TestGroupTargets(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(pickup.group_targets, contains(group))
+        assert_that(pickup.group_targets, contains_exactly(group))
 
     def test_delete(self):
         pickup = self.add_pickup()
@@ -318,7 +318,7 @@ class TestUsersFromGroupTargets(DAOTestCase):
         self.session.expire_all()
         assert_that(
             pickup.users_from_group_targets,
-            contains(contains(user1), contains(user2)),
+            contains_exactly(contains_exactly(user1), contains_exactly(user2)),
         )
 
     def test_getter_when_empty(self):
@@ -331,7 +331,7 @@ class TestUsersFromGroupTargets(DAOTestCase):
         self.session.expire_all()
         assert_that(
             pickup.users_from_group_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
 
 

--- a/xivo_dao/alchemy/tests/test_pjsip_transport.py
+++ b/xivo_dao/alchemy/tests/test_pjsip_transport.py
@@ -1,7 +1,7 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, equal_to, has_properties, contains, contains_inanyorder
+from hamcrest import assert_that, equal_to, has_properties, contains_exactly, contains_inanyorder
 from sqlalchemy import func
 from xivo_dao.tests.test_dao import DAOTestCase
 from ..pjsip_transport import PJSIPTransport
@@ -28,9 +28,9 @@ class TestPJSIPTransport(DAOTestCase):
         assert_that(row, has_properties(
             name='my-transport',
             options=contains_inanyorder(
-                contains('local_net', network),
-                contains('external_media_address', public_ip),
-                contains('external_signaling_address', public_ip),
+                contains_exactly('local_net', network),
+                contains_exactly('external_media_address', public_ip),
+                contains_exactly('external_signaling_address', public_ip),
             )
         ))
 

--- a/xivo_dao/alchemy/tests/test_queuefeatures.py
+++ b/xivo_dao/alchemy/tests/test_queuefeatures.py
@@ -1,9 +1,9 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -233,7 +233,7 @@ class TestUserQueueMembers(DAOTestCase):
         queue_member2 = self.add_queue_member(category='queue', usertype='user', queue_name=queue.name, position=2)
 
         self.session.expire_all()
-        assert_that(queue.user_queue_members, contains(queue_member1, queue_member2))
+        assert_that(queue.user_queue_members, contains_exactly(queue_member1, queue_member2))
 
     def test_setter(self):
         queue = self.add_queuefeatures()
@@ -242,7 +242,7 @@ class TestUserQueueMembers(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(queue.user_queue_members, contains(queue_member))
+        assert_that(queue.user_queue_members, contains_exactly(queue_member))
         assert_that(queue_member.queue_name, equal_to(queue.name))
 
     def test_deleter(self):
@@ -276,7 +276,7 @@ class TestAgentQueueMembers(DAOTestCase):
         queue_member2 = self.add_queue_member(category='queue', usertype='agent', queue_name=queue.name, position=2)
 
         self.session.expire_all()
-        assert_that(queue.agent_queue_members, contains(queue_member1, queue_member2))
+        assert_that(queue.agent_queue_members, contains_exactly(queue_member1, queue_member2))
 
     def test_setter(self):
         queue = self.add_queuefeatures()
@@ -285,7 +285,7 @@ class TestAgentQueueMembers(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(queue.agent_queue_members, contains(queue_member))
+        assert_that(queue.agent_queue_members, contains_exactly(queue_member))
         assert_that(queue_member.queue_name, equal_to(queue.name))
 
     def test_deleter(self):
@@ -319,7 +319,7 @@ class TestSchedules(DAOTestCase):
         self.add_schedule_path(path='queue', pathid=queue.id, schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(queue.schedules, contains(schedule))
+        assert_that(queue.schedules, contains_exactly(schedule))
 
     def test_setter(self):
         queue = self.add_queuefeatures()
@@ -579,7 +579,7 @@ class TestExtensions(DAOTestCase):
         extension = self.add_extension(type='queue', typeval=str(queue.id))
 
         self.session.expire_all()
-        assert_that(queue.extensions, contains(extension))
+        assert_that(queue.extensions, contains_exactly(extension))
 
 
 class TestExten(DAOTestCase):

--- a/xivo_dao/alchemy/tests/test_queuemember.py
+++ b/xivo_dao/alchemy/tests/test_queuemember.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest.mock import Mock
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     empty,
     has_properties,
@@ -258,11 +258,11 @@ class TestUsersFromCallPickupGroupInterceptorUserTargets(DAOTestCase):
 
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_user_targets,
-            contains(contains(user_target1, user_target2)),
+            contains_exactly(contains_exactly(user_target1, user_target2)),
         )
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_group_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
 
     def test_two_pickups_two_user_targets(self):
@@ -305,11 +305,11 @@ class TestUsersFromCallPickupGroupInterceptorUserTargets(DAOTestCase):
 
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_user_targets,
-            contains(contains(user_target1), contains(user_target2)),
+            contains_exactly(contains_exactly(user_target1), contains_exactly(user_target2)),
         )
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_group_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
 
 
@@ -361,11 +361,11 @@ class TestUsersFromCallPickupGroupInterceptorGroupTargets(DAOTestCase):
 
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_user_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_group_targets,
-            contains(contains(contains(user_target1), contains(user_target2))),
+            contains_exactly(contains_exactly(contains_exactly(user_target1), contains_exactly(user_target2))),
         )
 
     def test_two_pickups_two_user_targets(self):
@@ -422,12 +422,12 @@ class TestUsersFromCallPickupGroupInterceptorGroupTargets(DAOTestCase):
 
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_user_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
         assert_that(
             queue_member.users_from_call_pickup_group_interceptor_group_targets,
-            contains(
-                contains(contains(user_target1)),
-                contains(contains(user_target2)),
+            contains_exactly(
+                contains_exactly(contains_exactly(user_target1)),
+                contains_exactly(contains_exactly(user_target2)),
             ),
         )

--- a/xivo_dao/alchemy/tests/test_queueskillrule.py
+++ b/xivo_dao/alchemy/tests/test_queueskillrule.py
@@ -1,9 +1,9 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     empty,
 )
@@ -16,7 +16,7 @@ class TestRules(DAOTestCase):
 
     def test_getter(self):
         skill_rule = QueueSkillRule(rule='abcd;1234')
-        assert_that(skill_rule.rules, contains('abcd', '1234'))
+        assert_that(skill_rule.rules, contains_exactly('abcd', '1234'))
 
     def test_getter_empty(self):
         skill_rule = QueueSkillRule(rule=None)

--- a/xivo_dao/alchemy/tests/test_schedule.py
+++ b/xivo_dao/alchemy/tests/test_schedule.py
@@ -1,11 +1,11 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     none,
@@ -26,7 +26,7 @@ class TestIncalls(DAOTestCase):
         self.add_schedule_path(path='incall', pathid=incall.id, schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(schedule.incalls, contains(incall))
+        assert_that(schedule.incalls, contains_exactly(incall))
 
     def test_getter_empty_when_other_schedulepath(self):
         schedule = self.add_schedule()
@@ -45,7 +45,7 @@ class TestGroups(DAOTestCase):
         self.add_schedule_path(path='group', pathid=group.id, schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(schedule.groups, contains(group))
+        assert_that(schedule.groups, contains_exactly(group))
 
     def test_getter_empty_when_other_schedulepath(self):
         schedule = self.add_schedule()
@@ -64,7 +64,7 @@ class TestOutcalls(DAOTestCase):
         self.add_schedule_path(path='outcall', pathid=outcall.id, schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(schedule.outcalls, contains(outcall))
+        assert_that(schedule.outcalls, contains_exactly(outcall))
 
     def test_getter_empty_when_other_schedulepath(self):
         schedule = self.add_schedule()
@@ -83,7 +83,7 @@ class TestQueues(DAOTestCase):
         self.add_schedule_path(path='queue', pathid=queue.id, schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(schedule.queues, contains(queue))
+        assert_that(schedule.queues, contains_exactly(queue))
 
     def test_getter_empty_when_other_schedulepath(self):
         schedule = self.add_schedule()
@@ -102,7 +102,7 @@ class TestUsers(DAOTestCase):
         self.add_schedule_path(path='user', pathid=user.id, schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(schedule.users, contains(user))
+        assert_that(schedule.users, contains_exactly(user))
 
     def test_getter_empty_when_other_schedulepath(self):
         schedule = self.add_schedule()
@@ -121,7 +121,7 @@ class TestOpenPeriods(DAOTestCase):
         self.add_schedule_time(mode='closed', schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(schedule.open_periods, contains(open_period))
+        assert_that(schedule.open_periods, contains_exactly(open_period))
 
     def test_setter(self):
         schedule = self.add_schedule()
@@ -131,7 +131,7 @@ class TestOpenPeriods(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(schedule.open_periods, contains(open_period))
+        assert_that(schedule.open_periods, contains_exactly(open_period))
         assert_that(schedule.exceptional_periods, empty())
 
     def test_setter_to_empty(self):
@@ -144,7 +144,7 @@ class TestOpenPeriods(DAOTestCase):
 
         self.session.expire_all()
         assert_that(schedule.open_periods, empty())
-        assert_that(schedule.exceptional_periods, contains(exceptional_period))
+        assert_that(schedule.exceptional_periods, contains_exactly(exceptional_period))
 
 
 class TestExceptionalPeriods(DAOTestCase):
@@ -155,7 +155,7 @@ class TestExceptionalPeriods(DAOTestCase):
         self.add_schedule_time(mode='opened', schedule_id=schedule.id)
 
         self.session.expire_all()
-        assert_that(schedule.exceptional_periods, contains(exceptional_period))
+        assert_that(schedule.exceptional_periods, contains_exactly(exceptional_period))
 
     def test_setter(self):
         schedule = self.add_schedule()
@@ -165,7 +165,7 @@ class TestExceptionalPeriods(DAOTestCase):
         self.session.flush()
 
         self.session.expire_all()
-        assert_that(schedule.exceptional_periods, contains(exceptional_period))
+        assert_that(schedule.exceptional_periods, contains_exactly(exceptional_period))
         assert_that(schedule.open_periods, empty())
 
     def test_setter_to_empty(self):
@@ -178,7 +178,7 @@ class TestExceptionalPeriods(DAOTestCase):
 
         self.session.expire_all()
         assert_that(schedule.exceptional_periods, empty())
-        assert_that(schedule.open_periods, contains(open_period))
+        assert_that(schedule.open_periods, contains_exactly(open_period))
 
 
 class TestType(unittest.TestCase):

--- a/xivo_dao/alchemy/tests/test_schedule_time.py
+++ b/xivo_dao/alchemy/tests/test_schedule_time.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
-from hamcrest import assert_that, contains, equal_to
+from hamcrest import assert_that, contains_exactly, equal_to
 
 
 from xivo_dao.alchemy.schedule_time import ScheduleTime
@@ -67,11 +67,11 @@ class TestWeekDays(unittest.TestCase):
 
     def test_getter_mix_range(self):
         schedule_time = ScheduleTime(weekdays='1,4-7,10')
-        assert_that(schedule_time.week_days, contains(1, 4, 5, 6, 7, 10))
+        assert_that(schedule_time.week_days, contains_exactly(1, 4, 5, 6, 7, 10))
 
     def test_getter_none(self):
         schedule_time = ScheduleTime(weekdays=None)
-        assert_that(schedule_time.week_days, contains(
+        assert_that(schedule_time.week_days, contains_exactly(
             1, 2, 3, 4, 5, 6, 7,
         ))
 
@@ -88,11 +88,11 @@ class TestMonthDays(unittest.TestCase):
 
     def test_getter_mix_range(self):
         schedule_time = ScheduleTime(monthdays='1,4-7,10')
-        assert_that(schedule_time.month_days, contains(1, 4, 5, 6, 7, 10))
+        assert_that(schedule_time.month_days, contains_exactly(1, 4, 5, 6, 7, 10))
 
     def test_getter_none(self):
         schedule_time = ScheduleTime(monthdays=None)
-        assert_that(schedule_time.month_days, contains(
+        assert_that(schedule_time.month_days, contains_exactly(
             1, 2, 3, 4, 5, 6, 7, 8, 9,
             10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
             20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
@@ -112,11 +112,11 @@ class TestMonthsList(unittest.TestCase):
 
     def test_getter_mix_range(self):
         schedule_time = ScheduleTime(months='1,4-7,10')
-        assert_that(schedule_time.months_list, contains(1, 4, 5, 6, 7, 10))
+        assert_that(schedule_time.months_list, contains_exactly(1, 4, 5, 6, 7, 10))
 
     def test_getter_none(self):
         schedule_time = ScheduleTime(months=None)
-        assert_that(schedule_time.months_list, contains(
+        assert_that(schedule_time.months_list, contains_exactly(
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
         ))
 

--- a/xivo_dao/alchemy/tests/test_userfeatures.py
+++ b/xivo_dao/alchemy/tests/test_userfeatures.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -55,7 +55,7 @@ class TestLines(DAOTestCase):
         self.add_user_line(user_id=user.id, line_id=line1.id, main_line=False)
         self.add_user_line(user_id=user.id, line_id=line2.id, main_line=True)
 
-        assert_that(user.lines, contains(line2, line1))
+        assert_that(user.lines, contains_exactly(line2, line1))
 
     def test_creator(self):
         user = self.add_user()
@@ -64,13 +64,13 @@ class TestLines(DAOTestCase):
         user.lines = [line2, line1]
         self.session.flush()
 
-        assert_that(user.user_lines, contains(
+        assert_that(user.user_lines, contains_exactly(
             has_properties(line_id=line2.id,
                            main_line=True),
             has_properties(line_id=line1.id,
                            main_line=False)
         ))
-        assert_that(user.lines, contains(line2, line1))
+        assert_that(user.lines, contains_exactly(line2, line1))
 
 
 class TestIncalls(DAOTestCase):
@@ -184,7 +184,7 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         )
 
         assert_that(
-            user_interceptor.call_pickup_interceptor_pickups, contains(call_pickup)
+            user_interceptor.call_pickup_interceptor_pickups, contains_exactly(call_pickup)
         )
 
     def test_one_pickup_two_user_targets(self):
@@ -200,15 +200,15 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             user_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup1),
+            contains_exactly(call_pickup1),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_user_targets,
-            contains(contains_inanyorder(user_target1, user_target2)),
+            contains_exactly(contains_inanyorder(user_target1, user_target2)),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
 
     def test_two_pickups_two_user_targets(self):
@@ -228,16 +228,16 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             user_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup1, call_pickup2),
+            contains_exactly(call_pickup1, call_pickup2),
         )
 
         assert_that(
             user_interceptor.users_from_call_pickup_user_targets,
-            contains_inanyorder(contains(user_target1), contains(user_target2)),
+            contains_inanyorder(contains_exactly(user_target1), contains_exactly(user_target2)),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
 
     # Groups
@@ -260,16 +260,16 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             user_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup),
+            contains_exactly(call_pickup),
         )
 
         assert_that(
             user_interceptor.users_from_call_pickup_user_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_targets,
-            contains(contains(contains(user_target))),
+            contains_exactly(contains_exactly(contains_exactly(user_target))),
         )
 
     def test_one_pickup_two_group_targets(self):
@@ -299,19 +299,19 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             user_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup1),
+            contains_exactly(call_pickup1),
         )
 
         assert_that(
             user_interceptor.users_from_call_pickup_user_targets,
-            contains(empty()),
+            contains_exactly(empty()),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_targets,
-            contains(
+            contains_exactly(
                 contains_inanyorder(
-                    contains(user_target1),
-                    contains(user_target2),
+                    contains_exactly(user_target1),
+                    contains_exactly(user_target2),
                 ),
             ),
         )
@@ -346,18 +346,18 @@ class TestCallPickupInterceptorPickups(DAOTestCase):
         self.session.expire_all()
         assert_that(
             user_interceptor.call_pickup_interceptor_pickups,
-            contains(call_pickup1, call_pickup2),
+            contains_exactly(call_pickup1, call_pickup2),
         )
 
         assert_that(
             user_interceptor.users_from_call_pickup_user_targets,
-            contains(empty(), empty()),
+            contains_exactly(empty(), empty()),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_targets,
-            contains(
-                contains(contains(user_target1)),
-                contains(contains(user_target2)),
+            contains_exactly(
+                contains_exactly(contains_exactly(user_target1)),
+                contains_exactly(contains_exactly(user_target2)),
             ),
         )
 
@@ -396,11 +396,11 @@ class TestUsersFromCallPickupGroupInterceptorsUserTargets(DAOTestCase):
 
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_user_targets,
-            contains(contains(contains_inanyorder(user_target1, user_target2))),
+            contains_exactly(contains_exactly(contains_inanyorder(user_target1, user_target2))),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_group_targets,
-            contains(contains(empty())),
+            contains_exactly(contains_exactly(empty())),
         )
 
     def test_two_pickups_two_user_targets(self):
@@ -443,16 +443,16 @@ class TestUsersFromCallPickupGroupInterceptorsUserTargets(DAOTestCase):
 
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_user_targets,
-            contains(
+            contains_exactly(
                 contains_inanyorder(
-                    contains(user_target1),
-                    contains(user_target2),
+                    contains_exactly(user_target1),
+                    contains_exactly(user_target2),
                 )
             ),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_group_targets,
-            contains(contains(empty(), empty())),
+            contains_exactly(contains_exactly(empty(), empty())),
         )
 
 
@@ -504,15 +504,15 @@ class TestUsersFromCallPickupGroupInterceptorsGroupTargets(DAOTestCase):
 
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_user_targets,
-            contains(contains(empty())),
+            contains_exactly(contains_exactly(empty())),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_group_targets,
-            contains(
-                contains(
+            contains_exactly(
+                contains_exactly(
                     contains_inanyorder(
-                        contains(user_target1),
-                        contains(user_target2),
+                        contains_exactly(user_target1),
+                        contains_exactly(user_target2),
                     ),
                 ),
             ),
@@ -572,13 +572,13 @@ class TestUsersFromCallPickupGroupInterceptorsGroupTargets(DAOTestCase):
 
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_user_targets,
-            contains(contains(empty(), empty())),
+            contains_exactly(contains_exactly(empty(), empty())),
         )
         assert_that(
             user_interceptor.users_from_call_pickup_group_interceptors_group_targets,
-            contains(contains(
-                contains(contains(user_target1)),
-                contains(contains(user_target2)),
+            contains_exactly(contains_exactly(
+                contains_exactly(contains_exactly(user_target1)),
+                contains_exactly(contains_exactly(user_target2)),
             )),
         )
 
@@ -649,7 +649,7 @@ class TestSchedules(DAOTestCase):
 
         row = self.session.query(UserFeatures).filter_by(uuid=user.uuid).first()
         assert_that(row, equal_to(user))
-        assert_that(row.schedules, contains(schedule))
+        assert_that(row.schedules, contains_exactly(schedule))
 
     def test_setter(self):
         user = self.add_user()

--- a/xivo_dao/queue_log_dao.py
+++ b/xivo_dao/queue_log_dao.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import between, distinct
+from sqlalchemy import between, distinct, literal_column
 from sqlalchemy.sql import text
 from sqlalchemy.sql.expression import and_, or_
 from sqlalchemy.sql.functions import min
@@ -36,9 +36,9 @@ AND
     formatted_end = end.strftime('%Y-%m-%d %H:%M:%S%z')
 
     rows = session.query(
-        'start',
-        'end',
-        'agent_id'
+        literal_column('start'),
+        literal_column('end'),
+        literal_column('agent_id')
     ).from_statement(text(wrapup_times_query)).params(start=formatted_start,
                                                       end=formatted_end)
 

--- a/xivo_dao/resources/access_feature/tests/test_dao.py
+++ b/xivo_dao/resources/access_feature/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -90,7 +90,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_access_features(self):
         result = access_feature_dao.find_all_by(feature='noresult')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by(self):
         access_feature1 = self.add_accessfeatures(host='1.2.3.0/24', enabled=False)

--- a/xivo_dao/resources/agent/tests/test_dao.py
+++ b/xivo_dao/resources/agent/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_items,
@@ -187,7 +187,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_agent(self):
         result = agent_dao.find_all_by(firstname='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_custom_column(self):
         pass
@@ -423,7 +423,7 @@ class TestAssociateAgentSkill(DAOTestCase):
         agent_dao.associate_agent_skill(agent, AgentQueueSkill(skill=skill))
 
         self.session.expire_all()
-        assert_that(agent.agent_queue_skills, contains(
+        assert_that(agent.agent_queue_skills, contains_exactly(
             has_properties(
                 agentid=agent.id,
                 skillid=skill.id,
@@ -441,7 +441,7 @@ class TestAssociateAgentSkill(DAOTestCase):
         agent_dao.associate_agent_skill(agent, agent_skill)
 
         self.session.expire_all()
-        assert_that(agent.agent_queue_skills, contains(agent_skill))
+        assert_that(agent.agent_queue_skills, contains_exactly(agent_skill))
 
 
 class TestDissociateAgentSkill(DAOTestCase):

--- a/xivo_dao/resources/application/tests/test_dao.py
+++ b/xivo_dao/resources/application/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -139,7 +139,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_application(self):
         result = application_dao.find_all_by(name='my_name')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by(self):
         application1 = self.add_application(name='MyApplication')

--- a/xivo_dao/resources/asterisk_file/tests/test_dao.py
+++ b/xivo_dao/resources/asterisk_file/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -57,5 +57,5 @@ class TestEditSectionVariables(DAOTestCase):
         asterisk_file_dao.edit_section_variables(section, [variable])
 
         results = self.session.query(AsteriskFileVariable).all()
-        assert_that(results, contains(variable))
+        assert_that(results, contains_exactly(variable))
         assert_that(results, not_(has_items(old_variable)))

--- a/xivo_dao/resources/call_filter/tests/test_dao.py
+++ b/xivo_dao/resources/call_filter/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     empty,
     has_items,
@@ -159,7 +159,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_call_filters(self):
         result = call_filter_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         call_filter1 = self.add_call_filter(name='bob', enabled=True)
@@ -408,7 +408,7 @@ class TestAssociateTargets(DAOTestCase):
         call_filter_dao.associate_recipients(call_filter, [recipient])
 
         self.session.expire_all()
-        assert_that(call_filter.recipients, contains(recipient))
+        assert_that(call_filter.recipients, contains_exactly(recipient))
 
     def test_associate_multiple(self):
         call_filter = self.add_call_filter()
@@ -418,7 +418,7 @@ class TestAssociateTargets(DAOTestCase):
         call_filter_dao.associate_recipients(call_filter, [recipient1, recipient2])
 
         self.session.expire_all()
-        assert_that(call_filter.recipients, contains(recipient1, recipient2))
+        assert_that(call_filter.recipients, contains_exactly(recipient1, recipient2))
 
     def test_dissociate(self):
         call_filter = self.add_call_filter()
@@ -443,7 +443,7 @@ class TestAssociateInterceptors(DAOTestCase):
         call_filter_dao.associate_surrogates(call_filter, [surrogate])
 
         self.session.expire_all()
-        assert_that(call_filter.surrogates, contains(surrogate))
+        assert_that(call_filter.surrogates, contains_exactly(surrogate))
 
     def test_associate_multiple(self):
         call_filter = self.add_call_filter()
@@ -453,7 +453,7 @@ class TestAssociateInterceptors(DAOTestCase):
         call_filter_dao.associate_surrogates(call_filter, [surrogate1, surrogate2])
 
         self.session.expire_all()
-        assert_that(call_filter.surrogates, contains(surrogate1, surrogate2))
+        assert_that(call_filter.surrogates, contains_exactly(surrogate1, surrogate2))
 
     def test_dissociate(self):
         call_filter = self.add_call_filter()

--- a/xivo_dao/resources/call_permission/tests/test_dao.py
+++ b/xivo_dao/resources/call_permission/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_items,
@@ -149,7 +149,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_call_permissions(self):
         result = call_permission_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         call_permission1 = self.add_call_permission(name='bob', enabled=True)

--- a/xivo_dao/resources/call_pickup/tests/test_dao.py
+++ b/xivo_dao/resources/call_pickup/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     empty,
@@ -175,7 +175,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_call_pickups(self):
         result = call_pickup_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         call_pickup1 = self.add_pickup(name='bob', enabled=True)

--- a/xivo_dao/resources/conference/tests/test_dao.py
+++ b/xivo_dao/resources/conference/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -143,7 +143,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_conferences(self):
         result = conference_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         pass

--- a/xivo_dao/resources/context/tests/test_dao.py
+++ b/xivo_dao/resources/context/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_items,
@@ -160,7 +160,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_context(self):
         result = context_dao.find_all_by(description='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_custom_column(self):
         pass
@@ -309,11 +309,11 @@ class TestCreate(DAOTestCase):
             name='myContext',
             label='My Context Label',
             type='outcall',
-            user_ranges=contains(has_properties(start='1000', end='1999')),
-            group_ranges=contains(has_properties(start='2000', end='2999')),
-            queue_ranges=contains(has_properties(start='3000', end='3999')),
-            conference_room_ranges=contains(has_properties(start='4000', end='4999')),
-            incall_ranges=contains(has_properties(start='1000', end='4999', did_length='2')),
+            user_ranges=contains_exactly(has_properties(start='1000', end='1999')),
+            group_ranges=contains_exactly(has_properties(start='2000', end='2999')),
+            queue_ranges=contains_exactly(has_properties(start='3000', end='3999')),
+            conference_room_ranges=contains_exactly(has_properties(start='4000', end='4999')),
+            incall_ranges=contains_exactly(has_properties(start='1000', end='4999', did_length='2')),
             description='context description',
             enabled=False)
         )
@@ -355,11 +355,11 @@ class TestEdit(DAOTestCase):
             tenant_uuid=tenant.uuid,
             label='Other Context Label',
             type='incall',
-            user_ranges=contains(has_properties(start='4000', end='4999')),
-            group_ranges=contains(has_properties(start='3000', end='3999')),
-            queue_ranges=contains(has_properties(start='2000', end='2999')),
-            conference_room_ranges=contains(has_properties(start='1000', end='1999')),
-            incall_ranges=contains(has_properties(start='4000', end='6999', did_length='4')),
+            user_ranges=contains_exactly(has_properties(start='4000', end='4999')),
+            group_ranges=contains_exactly(has_properties(start='3000', end='3999')),
+            queue_ranges=contains_exactly(has_properties(start='2000', end='2999')),
+            conference_room_ranges=contains_exactly(has_properties(start='1000', end='1999')),
+            incall_ranges=contains_exactly(has_properties(start='4000', end='6999', did_length='4')),
             description='other context description',
             enabled=True)
         )
@@ -442,7 +442,7 @@ class TestAssociateContexts(DAOTestCase):
         context_dao.associate_contexts(context, [included_context])
 
         self.session.expire_all()
-        assert_that(context.contexts, contains(included_context))
+        assert_that(context.contexts, contains_exactly(included_context))
 
     def test_associate_multiple(self):
         context = self.add_context()
@@ -452,7 +452,7 @@ class TestAssociateContexts(DAOTestCase):
         context_dao.associate_contexts(context, [included_context1, included_context2])
 
         self.session.expire_all()
-        assert_that(context.contexts, contains(included_context1, included_context2))
+        assert_that(context.contexts, contains_exactly(included_context1, included_context2))
 
     def test_dissociate(self):
         context = self.add_context()

--- a/xivo_dao/resources/endpoint_custom/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_custom/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_items,
@@ -93,7 +93,7 @@ class TestFindAllBy(DAOTestCase):
 
         custom = custom_dao.find_all_by(interface='custom/interface')
 
-        assert_that(custom, contains(custom_row))
+        assert_that(custom, contains_exactly(custom_row))
 
     def test_find_all_multi_tenant(self):
         tenant = self.add_tenant()

--- a/xivo_dao/resources/endpoint_sip/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_sip/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -7,7 +7,7 @@ import uuid
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -177,7 +177,7 @@ class TestGet(DAOTestCase):
             outbound_auth_section_options=[['type', 'auth']],
             template=True,
             transport=has_properties(uuid=transport.uuid),
-            templates=contains(
+            templates=contains_exactly(
                 has_properties(uuid=template_1.uuid),
                 has_properties(uuid=template_2.uuid),
             ),
@@ -421,7 +421,7 @@ class TestEdit(DAOTestCase):
             sip_dao.edit(sip)
 
             assert_that(sip, has_properties({
-                field: contains(contains(*options[0])),
+                field: contains_exactly(contains_exactly(*options[0])),
             }), name)
 
         for name, options in self.section_options.items():

--- a/xivo_dao/resources/extension/tests/test_dao.py
+++ b/xivo_dao/resources/extension/tests/test_dao.py
@@ -500,7 +500,7 @@ class TestDelete(TestExtension):
             .first()
         )
 
-        self.assertEqual(row, None)
+        assert row is None
 
 
 class TestRelationship(TestExtension):

--- a/xivo_dao/resources/extension/tests/test_dao.py
+++ b/xivo_dao/resources/extension/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -343,7 +343,7 @@ class TestFindAllBy(TestExtension):
     def test_find_all_by_no_extensions(self):
         result = extension_dao.find_all_by(exten='invalid')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         context = self.add_context(name='mycontext')

--- a/xivo_dao/resources/external_app/tests/test_dao.py
+++ b/xivo_dao/resources/external_app/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -138,7 +138,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_external_apps(self):
         result = external_app_dao.find_all_by(name='123')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         tenant1 = self.add_tenant()

--- a/xivo_dao/resources/feature_extension/tests/test_dao.py
+++ b/xivo_dao/resources/feature_extension/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from uuid import uuid4
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_items,
@@ -161,7 +161,7 @@ class TestFindAllBy(TestExtension):
     def test_find_all_by_no_extensions(self):
         result = feature_extension_dao.find_all_by(exten='invalid')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         extension1 = self.add_feature_extension(exten='1000')
@@ -330,7 +330,7 @@ class TestFindAllServiceExtensions(DAOTestCase):
     def test_given_no_extension_then_return_empty_list(self):
         extensions = feature_extension_dao.find_all_service_extensions()
 
-        assert_that(extensions, contains())
+        assert_that(extensions, contains_exactly())
 
     def test_given_all_service_extensions_then_returns_models(self):
         expected = self.add_feature_extensions()
@@ -352,7 +352,7 @@ class TestFindAllServiceExtensions(DAOTestCase):
 
         result = feature_extension_dao.find_all_service_extensions()
 
-        assert_that(result, contains(expected))
+        assert_that(result, contains_exactly(expected))
 
 
 class TestFindAllForwardExtensions(DAOTestCase):
@@ -378,7 +378,7 @@ class TestFindAllForwardExtensions(DAOTestCase):
     def test_given_no_extension_then_return_empty_list(self):
         extensions = feature_extension_dao.find_all_forward_extensions()
 
-        assert_that(extensions, contains())
+        assert_that(extensions, contains_exactly())
 
     def test_given_all_forward_extensions_then_returns_models(self):
         expected = self.add_feature_extensions()
@@ -398,7 +398,7 @@ class TestFindAllForwardExtensions(DAOTestCase):
 
         result = feature_extension_dao.find_all_forward_extensions()
 
-        assert_that(result, contains(expected))
+        assert_that(result, contains_exactly(expected))
 
 
 class TestFindAllAgentActionExtensions(DAOTestCase):
@@ -422,7 +422,7 @@ class TestFindAllAgentActionExtensions(DAOTestCase):
     def test_given_no_extension_then_return_empty_list(self):
         extensions = feature_extension_dao.find_all_agent_action_extensions()
 
-        assert_that(extensions, contains())
+        assert_that(extensions, contains_exactly())
 
     def test_given_all_agent_action_extensions_then_returns_models(self):
         expected = self.add_feature_extensions()
@@ -442,4 +442,4 @@ class TestFindAllAgentActionExtensions(DAOTestCase):
 
         result = feature_extension_dao.find_all_agent_action_extensions()
 
-        assert_that(result, contains(expected))
+        assert_that(result, contains_exactly(expected))

--- a/xivo_dao/resources/feature_extension/tests/test_dao.py
+++ b/xivo_dao/resources/feature_extension/tests/test_dao.py
@@ -271,7 +271,7 @@ class TestDelete(TestExtension):
             .first()
         )
 
-        self.assertEqual(row, None)
+        assert row is None
 
 
 class TestFindAllServiceExtensions(DAOTestCase):

--- a/xivo_dao/resources/features/tests/test_dao.py
+++ b/xivo_dao/resources/features/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -42,7 +42,7 @@ class TestFindAll(DAOTestCase):
 
         features = features_dao.find_all('general')
 
-        assert_that(features, contains(row3, row2, row1, row4))
+        assert_that(features, contains_exactly(row3, row2, row1, row4))
 
     def test_find_all_do_not_find_var_val_none(self):
         self.add_features(var_name='setting1',

--- a/xivo_dao/resources/func_key/tests/test_dao.py
+++ b/xivo_dao/resources/func_key/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     has_item,
     has_items,
@@ -42,7 +42,7 @@ class TestFindAllForwards(TestFuncKeyDao):
     def test_given_no_forwards_then_returns_empty_list(self):
         result = dao.find_all_forwards(1, 'unconditional')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_unconditional_forward_then_list_contains_unconditional_forward(self):
         number = '1234'
@@ -50,7 +50,7 @@ class TestFindAllForwards(TestFuncKeyDao):
 
         result = dao.find_all_forwards(user_row.id, 'unconditional')
 
-        assert_that(result, contains(
+        assert_that(result, contains_exactly(
             has_properties(
                 number=number,
             )
@@ -62,7 +62,7 @@ class TestFindAllForwards(TestFuncKeyDao):
 
         result = dao.find_all_forwards(user_row.id, 'noanswer')
 
-        assert_that(result, contains(
+        assert_that(result, contains_exactly(
             has_properties(
                 number=number,
             )
@@ -74,7 +74,7 @@ class TestFindAllForwards(TestFuncKeyDao):
 
         result = dao.find_all_forwards(user_row.id, 'busy')
 
-        assert_that(result, contains(
+        assert_that(result, contains_exactly(
             has_properties(
                 number=number,
             )

--- a/xivo_dao/resources/func_key/tests/test_hint_dao.py
+++ b/xivo_dao/resources/func_key/tests/test_hint_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     has_properties,
     empty,
@@ -140,7 +140,7 @@ class TestUserHints(TestHints):
 
         assert_that(
             hint_dao.user_hints(self.context.name),
-            contains(
+            contains_exactly(
                 has_properties(
                     user_id=user_row.id,
                     extension='1000',
@@ -155,7 +155,7 @@ class TestUserHints(TestHints):
 
         assert_that(
             hint_dao.user_hints(self.context.name),
-            contains(
+            contains_exactly(
                 has_properties(
                     user_id=user_row.id,
                     extension='1001',
@@ -170,7 +170,7 @@ class TestUserHints(TestHints):
 
         assert_that(
             hint_dao.user_hints(self.context.name),
-            contains(
+            contains_exactly(
                 has_properties(
                     user_id=user_row.id,
                     extension='1002',
@@ -225,7 +225,7 @@ class TestUserHints(TestHints):
 
         assert_that(
             hint_dao.user_hints(self.context.name),
-            contains(
+            contains_exactly(
                 has_properties(
                     user_id=user.id,
                     extension='1001',
@@ -274,7 +274,7 @@ class TestUserHints(TestHints):
 
         assert_that(
             hint_dao.user_hints(self.context.name),
-            contains(
+            contains_exactly(
                 has_properties(
                     user_id=user.id,
                     extension='1001',
@@ -329,7 +329,7 @@ class TestConferenceHints(TestHints):
         hints = hint_dao.conference_hints(context.name)
         assert_that(
             hints,
-            contains(
+            contains_exactly(
                 Hint(
                     user_id=None,
                     conference_id=conference.id,
@@ -359,7 +359,7 @@ class TestServiceHints(TestHints):
 
         assert_that(
             hint_dao.service_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(user_id=user_row.id, extension='*25', argument=None),
             ),
         )
@@ -398,7 +398,7 @@ class TestForwardHints(TestHints):
 
         assert_that(
             hint_dao.forward_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(user_id=user_row.id, extension='*23', argument='1234'),
             ),
         )
@@ -411,7 +411,7 @@ class TestForwardHints(TestHints):
 
         assert_that(
             hint_dao.forward_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(user_id=user_row.id, extension='*23', argument=None),
             ),
         )
@@ -424,7 +424,7 @@ class TestForwardHints(TestHints):
         user_row = self.add_user_and_func_key()
         self.add_func_key_to_user(destination_row, user_row)
 
-        assert_that(hint_dao.forward_hints(self.context.name), contains())
+        assert_that(hint_dao.forward_hints(self.context.name), contains_exactly())
 
     def test_given_no_blf_then_returns_no_hints(self):
         destination_row = self.create_forward_func_key('_*23.', 'fwdbusy', '1234')
@@ -432,7 +432,7 @@ class TestForwardHints(TestHints):
         user_row = self.add_user_and_func_key()
         self.add_func_key_to_user(destination_row, user_row, blf=False)
 
-        assert_that(hint_dao.forward_hints(self.context.name), contains())
+        assert_that(hint_dao.forward_hints(self.context.name), contains_exactly())
 
     def test_given_user_when_query_other_context_then_returns_no_hints(self):
         destination_row = self.create_forward_func_key('_*23.', 'fwdbusy', '1234')
@@ -440,7 +440,7 @@ class TestForwardHints(TestHints):
         user_row = self.add_user_and_func_key()
         self.add_func_key_to_user(destination_row, user_row)
 
-        assert_that(hint_dao.forward_hints('othercontext'), contains())
+        assert_that(hint_dao.forward_hints('othercontext'), contains_exactly())
 
     def test_forward_extension_with_xxx_pattern_is_cleaned(self):
         destination_row = self.create_forward_func_key('_*23XXXX', 'fwdbusy', '1234')
@@ -450,7 +450,7 @@ class TestForwardHints(TestHints):
 
         assert_that(
             hint_dao.forward_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(user_id=user_row.id, extension='*23', argument='1234'),
             ),
         )
@@ -465,7 +465,7 @@ class TestAgentHints(TestHints):
 
         assert_that(
             hint_dao.agent_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(
                     user_id=user_row.id,
                     extension='*31',
@@ -506,7 +506,7 @@ class TestAgentHints(TestHints):
 
         assert_that(
             hint_dao.agent_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(
                     user_id=user_row.id,
                     extension='*31',
@@ -525,7 +525,7 @@ class TestCustomHints(TestHints):
 
         assert_that(
             hint_dao.custom_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(user_id=None, extension='1234', argument=None),
             ),
         )
@@ -566,7 +566,7 @@ class TestBSFilterHints(TestHints):
 
         assert_that(
             hint_dao.bsfilter_hints(self.context.name),
-            contains(
+            contains_exactly(
                 Hint(user_id=None, extension='*37', argument=str(filtermember_row.id)),
             ),
         )
@@ -595,7 +595,7 @@ class TestGroupHints(TestHints):
             user_id=user_row.id, extension='*51', argument=str(destination_row.group_id)
         )
 
-        assert_that(hint_dao.groupmember_hints(self.context.name), contains(expected))
+        assert_that(hint_dao.groupmember_hints(self.context.name), contains_exactly(expected))
 
     def test_given_commented_extension_then_returns_no_hints(self):
         destination_row = self.create_group_member_func_key('_*51.', 'groupmemberjoin')
@@ -603,7 +603,7 @@ class TestGroupHints(TestHints):
         user_row = self.add_user_and_func_key()
         self.add_func_key_to_user(destination_row, user_row, blf=False)
 
-        assert_that(hint_dao.groupmember_hints(self.context.name), contains())
+        assert_that(hint_dao.groupmember_hints(self.context.name), contains_exactly())
 
     def test_given_no_blf_then_returns_no_hints(self):
         destination_row = self.create_group_member_func_key('_*51.', 'groupmemberjoin')
@@ -611,7 +611,7 @@ class TestGroupHints(TestHints):
         user_row = self.add_user_and_func_key()
         self.add_func_key_to_user(destination_row, user_row, blf=False)
 
-        assert_that(hint_dao.groupmember_hints(self.context.name), contains())
+        assert_that(hint_dao.groupmember_hints(self.context.name), contains_exactly())
 
     def test_given_user_when_querying_other_context_then_returns_no_hints(self):
         destination_row = self.create_group_member_func_key('_*51.', 'groupmemberjoin')
@@ -619,7 +619,7 @@ class TestGroupHints(TestHints):
         user_row = self.add_user_and_func_key()
         self.add_func_key_to_user(destination_row, user_row)
 
-        assert_that(hint_dao.groupmember_hints('othercontext'), contains())
+        assert_that(hint_dao.groupmember_hints('othercontext'), contains_exactly())
 
     def test_group_extension_with_xxx_pattern_is_cleaned(self):
         destination_row = self.create_group_member_func_key(
@@ -633,7 +633,7 @@ class TestGroupHints(TestHints):
             user_id=user_row.id, extension='*51', argument=str(destination_row.group_id)
         )
 
-        assert_that(hint_dao.groupmember_hints(self.context.name), contains(expected))
+        assert_that(hint_dao.groupmember_hints(self.context.name), contains_exactly(expected))
 
 
 class TestUserSharedHints(TestHints):

--- a/xivo_dao/resources/group/tests/test_dao.py
+++ b/xivo_dao/resources/group/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_items,
@@ -191,7 +191,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_group(self):
         result = group_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_custom_column(self):
         pass
@@ -541,7 +541,7 @@ class TestAssociateMemberUsers(DAOTestCase):
         group_dao.associate_all_member_users(group, [QueueMember(user=user)])
 
         self.session.expire_all()
-        assert_that(group.user_queue_members, contains(
+        assert_that(group.user_queue_members, contains_exactly(
             has_properties(
                 queue_name=group.name,
                 interface='PJSIP/sipname',
@@ -580,7 +580,7 @@ class TestAssociateMemberUsers(DAOTestCase):
         group_dao.associate_all_member_users(group, members)
 
         self.session.expire_all()
-        assert_that(group.user_queue_members, contains(
+        assert_that(group.user_queue_members, contains_exactly(
             has_properties(user=user2),
             has_properties(user=user3),
             has_properties(user=user1),
@@ -596,7 +596,7 @@ class TestAssociateMemberUsers(DAOTestCase):
         group_dao.associate_all_member_users(group, [QueueMember(user=user)])
 
         self.session.expire_all()
-        assert_that(group.user_queue_members, contains(
+        assert_that(group.user_queue_members, contains_exactly(
             has_properties(
                 queue_name=group.name,
                 interface='PJSIP/sipname',
@@ -613,7 +613,7 @@ class TestAssociateMemberUsers(DAOTestCase):
         group_dao.associate_all_member_users(group, [QueueMember(user=user)])
 
         self.session.expire_all()
-        assert_that(group.user_queue_members, contains(has_properties(user=user)))
+        assert_that(group.user_queue_members, contains_exactly(has_properties(user=user)))
 
         group_dao.associate_all_member_users(group, [])
 
@@ -636,7 +636,7 @@ class TestAssociateMemberExtensions(DAOTestCase):
         group_dao.associate_all_member_extensions(group, [QueueMember(extension=extension)])
 
         self.session.expire_all()
-        assert_that(group.extension_queue_members, contains(
+        assert_that(group.extension_queue_members, contains_exactly(
             has_properties(
                 queue_name=group.name,
                 interface='Local/123@default',
@@ -662,7 +662,7 @@ class TestAssociateMemberExtensions(DAOTestCase):
         group_dao.associate_all_member_extensions(group, members)
 
         self.session.expire_all()
-        assert_that(group.extension_queue_members, contains(
+        assert_that(group.extension_queue_members, contains_exactly(
             has_properties(interface='Local/456@default'),
             has_properties(interface='Local/789@default'),
             has_properties(interface='Local/123@default'),
@@ -674,7 +674,7 @@ class TestAssociateMemberExtensions(DAOTestCase):
         group_dao.associate_all_member_extensions(group, [QueueMember(extension=extension)])
 
         self.session.expire_all()
-        assert_that(group.extension_queue_members, contains(has_properties(interface='Local/123@default')))
+        assert_that(group.extension_queue_members, contains_exactly(has_properties(interface='Local/123@default')))
 
         group_dao.associate_all_member_extensions(group, [])
 
@@ -695,11 +695,11 @@ class TestAssociateCallPermission(DAOTestCase):
 
         result = self.session.query(Group).first()
         assert_that(result, equal_to(group))
-        assert_that(result.call_permissions, contains(call_permission))
+        assert_that(result.call_permissions, contains_exactly(call_permission))
 
         result = self.session.query(RightCall).first()
         assert_that(result, equal_to(call_permission))
-        assert_that(result.groups, contains(group))
+        assert_that(result.groups, contains_exactly(group))
 
     def test_associate_group_call_permission_already_associated(self):
         group = self.add_group()
@@ -710,11 +710,11 @@ class TestAssociateCallPermission(DAOTestCase):
 
         result = self.session.query(Group).first()
         assert_that(result, equal_to(group))
-        assert_that(result.call_permissions, contains(call_permission))
+        assert_that(result.call_permissions, contains_exactly(call_permission))
 
         result = self.session.query(RightCall).first()
         assert_that(result, equal_to(call_permission))
-        assert_that(result.groups, contains(group))
+        assert_that(result.groups, contains_exactly(group))
 
 
 class TestDissociateCallPermission(DAOTestCase):

--- a/xivo_dao/resources/iax_callnumberlimits/tests/test_dao.py
+++ b/xivo_dao/resources/iax_callnumberlimits/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
 )
@@ -53,4 +53,4 @@ class TestEditAll(DAOTestCase):
         iax_callnumberlimits_dao.edit_all([row])
 
         iax_callnumberlimits = iax_callnumberlimits_dao.find_all()
-        assert_that(iax_callnumberlimits, contains(row))
+        assert_that(iax_callnumberlimits, contains_exactly(row))

--- a/xivo_dao/resources/incall/tests/test_dao.py
+++ b/xivo_dao/resources/incall/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_items,
@@ -176,7 +176,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_incall(self):
         result = incall_dao.find_all_by(description='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_custom_column(self):
         incall1 = self.add_incall(preprocess_subroutine='mysub', destination=Dialaction(action='user', actionarg1='2'))
@@ -211,7 +211,7 @@ class TestFindAllBy(DAOTestCase):
         assert_that(result, empty())
 
         result = incall_dao.find_all_by(id=incall.id, tenant_uuids=[tenant.uuid])
-        assert_that(result, contains(incall))
+        assert_that(result, contains_exactly(incall))
 
 
 class TestSearch(DAOTestCase):
@@ -491,7 +491,7 @@ class TestRelationship(DAOTestCase):
         incall = incall_dao.get(incall_row.id)
 
         assert_that(incall, equal_to(incall_row))
-        assert_that(incall.extensions, contains(extension_row))
+        assert_that(incall.extensions, contains_exactly(extension_row))
 
     def test_group_relationship(self):
         group_row = self.add_group()

--- a/xivo_dao/resources/infos/tests/test_dao.py
+++ b/xivo_dao/resources/infos/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -21,5 +21,5 @@ class TestGetInfos(DAOTestCase):
 
         infos = infos_dao.get()
 
-        self.assertEqual(infos.uuid, xivo_uuid)
-        self.assertEqual(infos.wazo_version, wazo_version)
+        assert infos.uuid == xivo_uuid
+        assert infos.wazo_version == wazo_version

--- a/xivo_dao/resources/ivr/tests/test_dao.py
+++ b/xivo_dao/resources/ivr/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -64,7 +64,7 @@ class TestGet(DAOTestCase):
         ivr = ivr_dao.get(ivr_row.id)
 
         assert_that(ivr, equal_to(ivr_row))
-        assert_that(ivr.choices, contains())
+        assert_that(ivr.choices, contains_exactly())
 
     def test_get_multi_tenant(self):
         tenant = self.add_tenant()
@@ -161,7 +161,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_ivr(self):
         result = ivr_dao.find_all_by(description='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         ivr1 = self.add_ivr(description='MyIVR')
@@ -398,7 +398,7 @@ class TestCreate(DAOTestCase):
             timeout_destination=has_properties(action='user', actionarg1='2'),
             abort_destination=has_properties(action='user', actionarg1='3'),
         ))
-        assert_that(ivr.choices, contains(
+        assert_that(ivr.choices, contains_exactly(
             has_properties(exten='1', destination=has_properties(action='user', actionarg1='4')),
         ))
 
@@ -450,7 +450,7 @@ class TestEdit(DAOTestCase):
             invalid_destination=has_properties(action='user', actionarg1='3'),
             timeout_destination=has_properties(action='user', actionarg1='4'),
         ))
-        assert_that(ivr.choices, contains(
+        assert_that(ivr.choices, contains_exactly(
             has_properties(exten='2', destination=has_properties(action='none')),
         ))
 
@@ -544,7 +544,7 @@ class TestRelationship(DAOTestCase):
         )
 
         self.session.expire_all()
-        assert_that(ivr.choices, contains(ivr_choice))
+        assert_that(ivr.choices, contains_exactly(ivr_choice))
         assert_that(ivr.choices[0].destination, equal_to(dialaction))
 
     def test_incalls_relationship(self):

--- a/xivo_dao/resources/line/tests/test_dao.py
+++ b/xivo_dao/resources/line/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -10,7 +10,7 @@ from hamcrest import (
     is_not,
     none,
     has_length,
-    contains,
+    contains_exactly,
     has_properties,
     has_property,
     has_items,
@@ -459,7 +459,7 @@ class TestSearch(DAOTestCase):
             search_result,
             has_properties(
                 total=1,
-                items=contains(has_properties(id=line1.id)),
+                items=contains_exactly(has_properties(id=line1.id)),
             )
         )
 
@@ -550,7 +550,7 @@ class TestRelationship(DAOTestCase):
 
         line = line_dao.get(line_row.id)
         assert_that(line, equal_to(line_row))
-        assert_that(line.extensions, contains(extension2_row, extension1_row))
+        assert_that(line.extensions, contains_exactly(extension2_row, extension1_row))
 
     def test_users_relationship(self):
         user1_row = self.add_user()
@@ -561,7 +561,7 @@ class TestRelationship(DAOTestCase):
 
         line = line_dao.get(line_row.id)
         assert_that(line, equal_to(line_row))
-        assert_that(line.users, contains(user2_row, user1_row))
+        assert_that(line.users, contains_exactly(user2_row, user1_row))
 
 
 class TestAssociateSchedule(DAOTestCase):
@@ -574,7 +574,7 @@ class TestAssociateSchedule(DAOTestCase):
 
         self.session.expire_all()
         assert_that(line.application, equal_to(application))
-        assert_that(application.lines, contains(line))
+        assert_that(application.lines, contains_exactly(line))
 
     def test_associate_already_associated(self):
         line = self.add_line()

--- a/xivo_dao/resources/line_extension/tests/test_dao.py
+++ b/xivo_dao/resources/line_extension/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (assert_that,
                       any_of,
-                      contains,
+                      contains_exactly,
                       equal_to,
                       has_properties,
                       is_not,
@@ -119,7 +119,7 @@ class TestFindAllByLineId(TestLineExtensionDAO):
     def test_given_no_line_extensions_then_returns_empty_list(self):
         result = dao.find_all_by_line_id(1)
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_one_line_extension_then_returns_one_item(self):
         line = self.add_line()
@@ -129,8 +129,10 @@ class TestFindAllByLineId(TestLineExtensionDAO):
 
         result = dao.find_all_by_line_id(line_extension.line_id)
 
-        assert_that(result, contains(has_properties(line_id=line_extension.line_id,
-                                                    extension_id=line_extension.extension_id)))
+        assert_that(result, contains_exactly(has_properties(
+            line_id=line_extension.line_id,
+            extension_id=line_extension.extension_id,
+        )))
 
     def test_line_multiple_extensions(self):
         line = self.add_line()
@@ -143,10 +145,19 @@ class TestFindAllByLineId(TestLineExtensionDAO):
 
         result = dao.find_all_by_line_id(line.id)
 
-        assert_that(result, contains(has_properties(line_id=line.id,
-                                                    extension_id=extension1.id),
-                                     has_properties(line_id=line.id,
-                                                    extension_id=extension2.id)))
+        assert_that(
+            result,
+            contains_exactly(
+                has_properties(
+                    line_id=line.id,
+                    extension_id=extension1.id
+                ),
+                has_properties(
+                    line_id=line.id,
+                    extension_id=extension2.id
+                )
+            )
+        )
 
 
 class TestFindByExtensionId(TestLineExtensionDAO):

--- a/xivo_dao/resources/moh/tests/test_dao.py
+++ b/xivo_dao/resources/moh/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -157,7 +157,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_moh(self):
         result = moh_dao.find_all_by(label='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         moh1 = self.add_moh(label='mymoh')

--- a/xivo_dao/resources/outcall/tests/test_dao.py
+++ b/xivo_dao/resources/outcall/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     empty,
     equal_to,
     has_items,
@@ -176,7 +176,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_outcall(self):
         result = outcall_dao.find_all_by(description='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_custom_column(self):
         pass
@@ -481,11 +481,11 @@ class TestAssociateCallPermission(DAOTestCase):
 
         result = self.session.query(Outcall).first()
         assert_that(result, equal_to(outcall))
-        assert_that(result.call_permissions, contains(call_permission))
+        assert_that(result.call_permissions, contains_exactly(call_permission))
 
         result = self.session.query(RightCall).first()
         assert_that(result, equal_to(call_permission))
-        assert_that(result.outcalls, contains(outcall))
+        assert_that(result.outcalls, contains_exactly(outcall))
 
     def test_associate_already_associated(self):
         outcall = self.add_outcall()
@@ -496,7 +496,7 @@ class TestAssociateCallPermission(DAOTestCase):
 
         result = self.session.query(Outcall).first()
         assert_that(result, equal_to(outcall))
-        assert_that(result.call_permissions, contains(call_permission))
+        assert_that(result.call_permissions, contains_exactly(call_permission))
 
 
 class TestDissociateCallPermission(DAOTestCase):

--- a/xivo_dao/resources/paging/tests/test_dao.py
+++ b/xivo_dao/resources/paging/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -140,7 +140,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_pagings(self):
         result = paging_dao.find_all_by(number='123')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         paging1 = self.add_paging(announce_sound='sound')

--- a/xivo_dao/resources/parking_lot/tests/test_dao.py
+++ b/xivo_dao/resources/parking_lot/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -141,7 +141,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_parking_lots(self):
         result = parking_lot_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         pass

--- a/xivo_dao/resources/pjsip_transport/tests/test_dao.py
+++ b/xivo_dao/resources/pjsip_transport/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     has_items,
     has_properties,
@@ -92,7 +92,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_transports(self):
         result = dao.find_all_by(name='not-here')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         transport = self.add_transport(name='the-transport')
@@ -218,8 +218,8 @@ class TestCreate(DAOTestCase):
         assert_that(transport, has_properties(
             name='transport',
             options=contains_inanyorder(
-                contains('bind', '0.0.0.0'),
-                contains('protocol', 'wss'),
+                contains_exactly('bind', '0.0.0.0'),
+                contains_exactly('protocol', 'wss'),
             ),
         ))
 
@@ -253,11 +253,11 @@ class TestEdit(DAOTestCase):
         assert_that(transport, has_properties(
             name='other_transport',
             options=contains_inanyorder(
-                contains('bind', '0.0.0.0'),
-                contains('protocol', 'udp'),
-                contains('cos', '1'),
-                contains('local_net', '192.168.0.0/16'),
-                contains('local_net', '10.1.42.0/24'),
+                contains_exactly('bind', '0.0.0.0'),
+                contains_exactly('protocol', 'udp'),
+                contains_exactly('cos', '1'),
+                contains_exactly('local_net', '192.168.0.0/16'),
+                contains_exactly('local_net', '10.1.42.0/24'),
             ),
         ))
 

--- a/xivo_dao/resources/queue/tests/test_dao.py
+++ b/xivo_dao/resources/queue/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     empty,
     has_items,
@@ -160,7 +160,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_queue(self):
         result = queue_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_custom_column(self):
         pass
@@ -538,8 +538,8 @@ class TestAssociateSchedule(DAOTestCase):
         queue_dao.associate_schedule(queue, schedule)
 
         self.session.expire_all()
-        assert_that(queue.schedules, contains(schedule))
-        assert_that(schedule.queues, contains(queue))
+        assert_that(queue.schedules, contains_exactly(schedule))
+        assert_that(schedule.queues, contains_exactly(queue))
 
     def test_associate_already_associated(self):
         queue = self.add_queuefeatures()
@@ -549,7 +549,7 @@ class TestAssociateSchedule(DAOTestCase):
         queue_dao.associate_schedule(queue, schedule)
 
         self.session.expire_all()
-        assert_that(queue.schedules, contains(schedule))
+        assert_that(queue.schedules, contains_exactly(schedule))
 
 
 class TestDissociateSchedule(DAOTestCase):
@@ -586,7 +586,7 @@ class TestAssociateMemberUser(DAOTestCase):
         queue_dao.associate_member_user(queue, QueueMember(user=user))
 
         self.session.expire_all()
-        assert_that(queue.user_queue_members, contains(
+        assert_that(queue.user_queue_members, contains_exactly(
             has_properties(
                 queue_name=queue.name,
                 category='queue',
@@ -605,7 +605,7 @@ class TestAssociateMemberUser(DAOTestCase):
         queue_dao.associate_member_user(queue, QueueMember(user=user))
 
         self.session.expire_all()
-        assert_that(queue.user_queue_members, contains(
+        assert_that(queue.user_queue_members, contains_exactly(
             has_properties(
                 interface='PJSIP/sipname',
                 channel='SIP',
@@ -626,7 +626,7 @@ class TestAssociateMemberUser(DAOTestCase):
         queue_dao.associate_member_user(queue, queue_member)
 
         self.session.expire_all()
-        assert_that(queue.user_queue_members, contains(queue_member))
+        assert_that(queue.user_queue_members, contains_exactly(queue_member))
 
 
 class TestDissociateMemberUser(DAOTestCase):
@@ -662,7 +662,7 @@ class TestAssociateMemberAgent(DAOTestCase):
         queue_dao.associate_member_agent(queue, QueueMember(agent=agent))
 
         self.session.expire_all()
-        assert_that(queue.agent_queue_members, contains(
+        assert_that(queue.agent_queue_members, contains_exactly(
             has_properties(
                 queue_name=queue.name,
                 category='queue',
@@ -678,7 +678,7 @@ class TestAssociateMemberAgent(DAOTestCase):
         queue_dao.associate_member_agent(queue, QueueMember(agent=agent))
 
         self.session.expire_all()
-        assert_that(queue.agent_queue_members, contains(
+        assert_that(queue.agent_queue_members, contains_exactly(
             has_properties(
                 interface='Agent/1234',
                 channel='Agent',
@@ -696,7 +696,7 @@ class TestAssociateMemberAgent(DAOTestCase):
         queue_dao.associate_member_agent(queue, queue_member)
 
         self.session.expire_all()
-        assert_that(queue.agent_queue_members, contains(queue_member))
+        assert_that(queue.agent_queue_members, contains_exactly(queue_member))
 
 
 class TestDissociateMemberAgent(DAOTestCase):

--- a/xivo_dao/resources/queue_general/tests/test_dao.py
+++ b/xivo_dao/resources/queue_general/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
 )
@@ -30,7 +30,7 @@ class TestFindAll(DAOTestCase):
 
         queue_general = queue_general_dao.find_all()
 
-        assert_that(queue_general, contains(row3, row2, row1, row4))
+        assert_that(queue_general, contains_exactly(row3, row2, row1, row4))
 
     def test_find_all_do_not_find_var_val_none(self):
         self.add_queue_general_settings(var_metric=1, var_name='monitor-type', var_val=None)
@@ -38,7 +38,7 @@ class TestFindAll(DAOTestCase):
 
         queue_general = queue_general_dao.find_all()
 
-        assert_that(queue_general, contains(row2))
+        assert_that(queue_general, contains_exactly(row2))
 
 
 class TestEditAll(DAOTestCase):
@@ -64,4 +64,4 @@ class TestEditAll(DAOTestCase):
 
         self.session.expire_all()
         queue_general = queue_general_dao.find_all()
-        assert_that(queue_general, contains(row))
+        assert_that(queue_general, contains_exactly(row))

--- a/xivo_dao/resources/sccp_general/tests/test_dao.py
+++ b/xivo_dao/resources/sccp_general/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
 )
@@ -49,4 +49,4 @@ class TestEditAll(DAOTestCase):
         sccp_general_dao.edit_all([row])
 
         sccp_general = sccp_general_dao.find_all()
-        assert_that(sccp_general, contains(row))
+        assert_that(sccp_general, contains_exactly(row))

--- a/xivo_dao/resources/schedule/tests/test_dao.py
+++ b/xivo_dao/resources/schedule/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -139,7 +139,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_schedules(self):
         result = schedule_dao.find_all_by(name='123')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         pass

--- a/xivo_dao/resources/skill/tests/test_dao.py
+++ b/xivo_dao/resources/skill/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -137,7 +137,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_skills(self):
         result = skill_dao.find_all_by(name='123')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by(self):
         skill1 = self.add_queue_skill(description='description')

--- a/xivo_dao/resources/skill_rule/tests/test_dao.py
+++ b/xivo_dao/resources/skill_rule/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     empty,
     has_items,
@@ -144,7 +144,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_skill_rules(self):
         result = skill_rule_dao.find_all_by(name='123')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by(self):
         skill_rule = self.add_queue_skill_rule(name='description')

--- a/xivo_dao/resources/switchboard/tests/tests_dao.py
+++ b/xivo_dao/resources/switchboard/tests/tests_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -296,7 +296,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_switchboards(self):
         result = switchboard_dao.find_all_by(name="switchboard")
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         switchboard1 = self.add_switchboard(name="switchboard")

--- a/xivo_dao/resources/tenant/tests/test_dao.py
+++ b/xivo_dao/resources/tenant/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     none,
@@ -124,7 +124,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_resource(self):
         result = dao.find_all_by(uuid=UNKNOWN_UUID)
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_multi_tenant(self):
         row = self.add_tenant()
@@ -133,7 +133,7 @@ class TestFindAllBy(DAOTestCase):
         assert_that(resources, has_items(row))
 
         resources = dao.find_all_by(uuid=row.uuid, tenant_uuids=[UNKNOWN_UUID])
-        assert_that(resources, contains())
+        assert_that(resources, contains_exactly())
 
 
 class TestSearch(DAOTestCase):

--- a/xivo_dao/resources/trunk/tests/test_dao.py
+++ b/xivo_dao/resources/trunk/tests/test_dao.py
@@ -1,11 +1,11 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -148,7 +148,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_trunk(self):
         result = trunk_dao.find_all_by(context='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         trunk1 = self.add_trunk(context='MyCôntext')

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -375,7 +375,7 @@ class TestSearch(TestUser):
         with self.assertRaises(exception) as exc:
             parameters.setdefault('tenant_uuids', [self.default_tenant.uuid])
             user_dao.search(**parameters)
-        self.assertEquals(str(exc.exception), exception_msg)
+        assert str(exc.exception) == exception_msg
 
     def assert_search_collated_raises_exception(
         self, exception, exception_msg, **parameters
@@ -383,7 +383,7 @@ class TestSearch(TestUser):
         with self.assertRaises(exception) as exc:
             parameters.setdefault('tenant_uuids', [self.default_tenant.uuid])
             user_dao.search_collated(**parameters)
-        self.assertEquals(str(exc.exception), exception_msg)
+        assert str(exc.exception) == exception_msg
 
 
 class TestSimpleSearch(TestSearch):

--- a/xivo_dao/resources/user/tests/test_dao.py
+++ b/xivo_dao/resources/user/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -6,7 +6,7 @@ import uuid
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -285,7 +285,7 @@ class TestFindAllBy(TestUser):
     def test_find_all_by_no_users(self):
         result = user_dao.find_all_by(firstname='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_renamed_column(self):
         template_row = self.add_func_key_template()
@@ -313,7 +313,7 @@ class TestCountAllBy(TestUser):
     def test_count_all_by_no_users(self):
         result = user_dao.count_all_by('subscription_type')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_count_all_by(self):
         self.add_user(subscription_type=1)
@@ -1234,7 +1234,7 @@ class TestAssociateGroups(DAOTestCase):
         assert_that(user, equal_to(user_row))
         assert_that(
             user.group_members,
-            contains(
+            contains_exactly(
                 has_properties(
                     queue_name=group.name,
                     interface='PJSIP/sipname',
@@ -1272,7 +1272,7 @@ class TestAssociateGroups(DAOTestCase):
         user = self.session.query(User).first()
         assert_that(
             user.group_members,
-            contains(
+            contains_exactly(
                 has_properties(
                     queue_name=group.name, interface='PJSIP/sipname', channel='SIP'
                 )
@@ -1291,7 +1291,7 @@ class TestAssociateGroups(DAOTestCase):
         user = self.session.query(User).first()
         assert_that(
             user.group_members,
-            contains(
+            contains_exactly(
                 has_properties(
                     queue_name=group.name, interface='SCCP/sccpname', channel='SCCP'
                 )
@@ -1310,7 +1310,7 @@ class TestAssociateGroups(DAOTestCase):
         user = self.session.query(User).first()
         assert_that(
             user.group_members,
-            contains(
+            contains_exactly(
                 has_properties(
                     queue_name=group.name,
                     interface='custom/interface',
@@ -1328,7 +1328,7 @@ class TestAssociateGroups(DAOTestCase):
         user_dao.associate_all_groups(user_row, [group])
 
         user = self.session.query(User).first()
-        assert_that(user.groups, contains(group))
+        assert_that(user.groups, contains_exactly(group))
 
         user_dao.associate_all_groups(user_row, [])
 

--- a/xivo_dao/resources/user_call_permission/tests/test_dao.py
+++ b/xivo_dao/resources/user_call_permission/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (assert_that,
@@ -8,7 +8,7 @@ from hamcrest import (assert_that,
                       has_length,
                       none,
                       has_items,
-                      contains)
+                      contains_exactly)
 
 from xivo_dao.alchemy.rightcallmember import RightCallMember as UserCallPermission
 from xivo_dao.helpers.exception import NotFoundError, InputError
@@ -30,14 +30,14 @@ class TestFindAllBy(DAOTestCase):
         user_call_permission = self.add_user_call_permission_with_user_and_call_permission()
 
         result = user_call_permission_dao.find_all_by(user_id=user_call_permission.user_id)
-        assert_that(result, contains(user_call_permission))
+        assert_that(result, contains_exactly(user_call_permission))
 
         result = user_call_permission_dao.find_all_by(call_permission_id=user_call_permission.call_permission_id)
-        assert_that(result, contains(user_call_permission))
+        assert_that(result, contains_exactly(user_call_permission))
 
         result = user_call_permission_dao.find_all_by(user_id=user_call_permission.user_id,
                                                       call_permission_id=user_call_permission.call_permission_id)
-        assert_that(result, contains(user_call_permission))
+        assert_that(result, contains_exactly(user_call_permission))
 
     def test_find_all_by_user_id_two_user_call_permissions(self):
         user = self.add_user()

--- a/xivo_dao/resources/user_external_app/tests/test_dao.py
+++ b/xivo_dao/resources/user_external_app/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2020-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     has_properties,
@@ -100,7 +100,7 @@ class TestFindAllBy(DAOTestCase):
         user = self.add_user()
         result = user_external_app_dao.find_all_by(user.uuid, name='123')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_native_column(self):
         user = self.add_user()

--- a/xivo_dao/resources/user_line/tests/test_dao.py
+++ b/xivo_dao/resources/user_line/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_length,
@@ -51,7 +51,7 @@ class TestFindAllByUserId(DAOTestCase):
 
         result = user_line_dao.find_all_by_user_id(user.id)
 
-        assert_that(result, contains(user_line))
+        assert_that(result, contains_exactly(user_line))
 
     def test_find_all_by_user_id_two_users(self):
         user = self.add_user()
@@ -336,7 +336,7 @@ class TestFindAllByLineId(DAOTestCase):
 
         result = user_line_dao.find_all_by_line_id(line.id)
 
-        assert_that(result, contains(user_line))
+        assert_that(result, contains_exactly(user_line))
 
     def test_find_all_by_line_id_two_user_lines(self):
         user1 = self.add_user()
@@ -367,7 +367,7 @@ class TestAssociateAllLines(DAOTestCase):
 
         result = user_line_dao.associate_all_lines(user, [line_1, line_2])
 
-        assert_that(result, contains(
+        assert_that(result, contains_exactly(
             has_properties(
                 user_id=user.id,
                 line_id=line_1.id,

--- a/xivo_dao/resources/user_voicemail/tests/test_dao.py
+++ b/xivo_dao/resources/user_voicemail/tests/test_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     has_properties,
@@ -116,7 +116,7 @@ class TestUserVoicemailFindAllByVoicemailId(TestUserVoicemail):
     def test_given_no_voicemails_then_returns_empty_list(self):
         result = user_voicemail_dao.find_all_by_voicemail_id(1)
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_voicemail_has_no_user_associated_then_returns_empty_list(self):
         context = self.add_context(name='default')
@@ -124,7 +124,7 @@ class TestUserVoicemailFindAllByVoicemailId(TestUserVoicemail):
 
         result = user_voicemail_dao.find_all_by_voicemail_id(voicemail_row.uniqueid)
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_voicemail_is_associated_to_user_then_returns_one_item(self):
         user = self.add_user()
@@ -133,8 +133,10 @@ class TestUserVoicemailFindAllByVoicemailId(TestUserVoicemail):
 
         result = user_voicemail_dao.find_all_by_voicemail_id(voicemail.id)
 
-        assert_that(result, contains(has_properties(user_id=user.id,
-                                                    voicemail_id=voicemail.id)))
+        assert_that(result, contains_exactly(has_properties(
+            user_id=user.id,
+            voicemail_id=voicemail.id
+        )))
 
     def test_given_voicemail_is_associated_to_two_users_then_returns_two_items(self):
         user1 = self.add_user()

--- a/xivo_dao/resources/utils/tests/test_search.py
+++ b/xivo_dao/resources/utils/tests/test_search.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -8,7 +8,7 @@ from unittest.mock import Mock, sentinel as s
 from hamcrest import assert_that
 from hamcrest import calling
 from hamcrest import equal_to
-from hamcrest import contains
+from hamcrest import contains_exactly
 from hamcrest import contains_inanyorder
 from hamcrest import has_length
 from hamcrest import is_in
@@ -97,12 +97,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session)
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(first_user_row, last_user_row))
+        assert_that(rows, contains_exactly(first_user_row, last_user_row))
 
         rows, total = self.search.search_collated(self.session)
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(first_user_row, last_user_row))
+        assert_that(rows, contains_exactly(first_user_row, last_user_row))
 
     def test_given_order_then_sorts_rows_using_order(self):
         user_row1 = self.add_user(firstname='Bob', lastname='Abigale')
@@ -112,12 +112,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'order': 'firstname'})
 
         assert_that(total, equal_to(3))
-        assert_that(rows, contains(user_row2, user_row1, user_row3))
+        assert_that(rows, contains_exactly(user_row2, user_row1, user_row3))
 
         rows, total = self.search.search_collated(self.session, {'order': 'firstname'})
 
         assert_that(total, equal_to(3))
-        assert_that(rows, contains(user_row2, user_row3, user_row1))
+        assert_that(rows, contains_exactly(user_row2, user_row3, user_row1))
 
     def test_given_direction_then_sorts_rows_using_direction(self):
         first_user_row = self.add_user(lastname='Abigale')
@@ -126,12 +126,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'direction': 'desc'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(last_user_row, first_user_row))
+        assert_that(rows, contains_exactly(last_user_row, first_user_row))
 
         rows, total = self.search.search_collated(self.session, {'direction': 'desc'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(last_user_row, first_user_row))
+        assert_that(rows, contains_exactly(last_user_row, first_user_row))
 
     def test_given_limit_is_negative_number_then_raises_error(self):
         self.assertRaises(InputError, self.search.search, self.session, {'limit': -1})
@@ -172,12 +172,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'offset': 1})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(last_user_row))
+        assert_that(rows, contains_exactly(last_user_row))
 
         rows, total = self.search.search_collated(self.session, {'offset': 1})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(last_user_row))
+        assert_that(rows, contains_exactly(last_user_row))
 
     def test_given_offset_is_zero_then_does_not_offset_rows(self):
         first_user_row = self.add_user(lastname='Abigale')
@@ -186,12 +186,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'offset': 0})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(first_user_row, last_user_row))
+        assert_that(rows, contains_exactly(first_user_row, last_user_row))
 
         rows, total = self.search.search_collated(self.session, {'offset': 0})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(first_user_row, last_user_row))
+        assert_that(rows, contains_exactly(first_user_row, last_user_row))
 
     def test_given_search_without_accent_term_then_searches_in_column_with_accent(self):
         user_row = self.add_user(firstname='accênt')
@@ -199,12 +199,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'search': 'accent'})
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row))
+        assert_that(rows, contains_exactly(user_row))
 
         rows, total = self.search.search_collated(self.session, {'search': 'accent'})
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row))
+        assert_that(rows, contains_exactly(user_row))
 
     def test_given_search_with_accent_term_then_searches_in_column_without_accent(self):
         user_row1 = self.add_user(firstname='accént')
@@ -213,12 +213,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'search': 'accént'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(user_row1, user_row2))
+        assert_that(rows, contains_exactly(user_row1, user_row2))
 
         rows, total = self.search.search_collated(self.session, {'search': 'accént'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(user_row1, user_row2))
+        assert_that(rows, contains_exactly(user_row1, user_row2))
 
     def test_given_search_term_then_searches_in_columns_and_uses_default_sort(self):
         user_row1 = self.add_user(firstname='a123bcd', lastname='eeefghi')
@@ -228,12 +228,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'search': '123'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(user_row2, user_row1))
+        assert_that(rows, contains_exactly(user_row2, user_row1))
 
         rows, total = self.search.search_collated(self.session, {'search': '123'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(user_row2, user_row1))
+        assert_that(rows, contains_exactly(user_row2, user_row1))
 
     def test_given_search_term_then_searches_in_numeric_columns(self):
         self.add_user(simultcalls=1)
@@ -242,12 +242,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'search': '2'})
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row2))
+        assert_that(rows, contains_exactly(user_row2))
 
         rows, total = self.search.search_collated(self.session, {'search': '2'})
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row2))
+        assert_that(rows, contains_exactly(user_row2))
 
     def test_given_exact_match_numeric_term_in_param(self):
         self.add_user(firstname='Alice', lastname='First', simultcalls=3)
@@ -258,14 +258,14 @@ class TestSearchSystem(DAOTestCase):
         )
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row2))
+        assert_that(rows, contains_exactly(user_row2))
 
         rows, total = self.search.search_collated(
             self.session, {'search': 'ali', 'simultcalls': '2'}
         )
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row2))
+        assert_that(rows, contains_exactly(user_row2))
 
     def test_given_exact_match_userfield_term_in_param(self):
         self.add_user(firstname='Alice', lastname='First', userfield='mtl')
@@ -276,14 +276,14 @@ class TestSearchSystem(DAOTestCase):
         )
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row2))
+        assert_that(rows, contains_exactly(user_row2))
 
         rows, total = self.search.search_collated(
             self.session, {'search': 'ali', 'userfield': 'qc'}
         )
 
         assert_that(total, equal_to(1))
-        assert_that(rows, contains(user_row2))
+        assert_that(rows, contains_exactly(user_row2))
 
     def test_given_exact_match_string_term_in_param_numeric_column(self):
         self.add_user(firstname='Alice', lastname='First', simultcalls=2)
@@ -308,12 +308,12 @@ class TestSearchSystem(DAOTestCase):
         rows, total = self.search.search(self.session, {'userfield': 'qc'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(user_row2, user_row3))
+        assert_that(rows, contains_exactly(user_row2, user_row3))
 
         rows, total = self.search.search_collated(self.session, {'userfield': 'qc'})
 
         assert_that(total, equal_to(2))
-        assert_that(rows, contains(user_row2, user_row3))
+        assert_that(rows, contains_exactly(user_row2, user_row3))
 
     def test_when_invalid_column(self):
         self.assert_search_raises_exception(
@@ -385,7 +385,7 @@ class TestSearchConfig(unittest.TestCase):
 
         result = config.all_search_columns()
 
-        assert_that(result, contains(column))
+        assert_that(result, contains_exactly(column))
 
     def test_given_list_of_columns_then_returns_all_all_search_columns(self):
         table = Mock()

--- a/xivo_dao/resources/utils/tests/test_search.py
+++ b/xivo_dao/resources/utils/tests/test_search.py
@@ -81,14 +81,14 @@ class TestSearchSystem(DAOTestCase):
     def assert_search_raises_exception(self, exception, exception_msg, **parameters):
         with self.assertRaises(exception) as exc:
             self.search.search(self.session, parameters)
-        self.assertEquals(str(exc.exception), exception_msg)
+        assert str(exc.exception) == exception_msg
 
     def assert_search_collated_raises_exception(
         self, exception, exception_msg, **parameters
     ):
         with self.assertRaises(exception) as exc:
             self.search.search_collated(self.session, parameters)
-        self.assertEquals(str(exc.exception), exception_msg)
+        assert str(exc.exception) == exception_msg
 
     def test_given_no_parameters_then_sorts_rows_using_default_sort_and_direction(self):
         last_user_row = self.add_user(lastname='Zintrabi')

--- a/xivo_dao/resources/voicemail/tests/test_dao.py
+++ b/xivo_dao/resources/voicemail/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     equal_to,
     empty,
@@ -161,7 +161,7 @@ class TestFindAllBy(DAOTestCase):
     def test_find_all_by_no_voicemail(self):
         result = voicemail_dao.find_all_by(name='toto')
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_all_by_custom_column(self):
         voicemail1 = self.add_voicemail(timezone='MyTimezone')

--- a/xivo_dao/resources/voicemail_general/tests/test_dao.py
+++ b/xivo_dao/resources/voicemail_general/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -30,7 +30,7 @@ class TestFindAll(DAOTestCase):
 
         voicemail_general = voicemail_general_dao.find_all()
 
-        assert_that(voicemail_general, contains(row3, row2, row1, row4))
+        assert_that(voicemail_general, contains_exactly(row3, row2, row1, row4))
 
     def test_find_all_do_not_find_register(self):
         self.add_voicemail_general_settings(category='zonemessages')
@@ -38,7 +38,7 @@ class TestFindAll(DAOTestCase):
 
         voicemail_general = voicemail_general_dao.find_all()
 
-        assert_that(voicemail_general, contains(row2))
+        assert_that(voicemail_general, contains_exactly(row2))
 
     def test_find_all_do_not_find_var_val_none(self):
         self.add_voicemail_general_settings(var_metric=1,
@@ -50,7 +50,7 @@ class TestFindAll(DAOTestCase):
 
         voicemail_general = voicemail_general_dao.find_all()
 
-        assert_that(voicemail_general, contains(row2))
+        assert_that(voicemail_general, contains_exactly(row2))
 
 
 class TestEditAll(DAOTestCase):
@@ -84,4 +84,4 @@ class TestEditAll(DAOTestCase):
         voicemail_general_dao.edit_all([row])
 
         voicemail_general = voicemail_general_dao.find_all()
-        assert_that(voicemail_general, contains(row))
+        assert_that(voicemail_general, contains_exactly(row))

--- a/xivo_dao/resources/voicemail_zonemessages/tests/test_dao.py
+++ b/xivo_dao/resources/voicemail_zonemessages/tests/test_dao.py
@@ -1,10 +1,10 @@
-# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 from hamcrest import (
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     has_properties,
@@ -44,7 +44,7 @@ class TestFindAll(DAOTestCase):
 
         voicemail_zonemessages = voicemail_zonemessages_dao.find_all()
 
-        assert_that(voicemail_zonemessages, contains(row2))
+        assert_that(voicemail_zonemessages, contains_exactly(row2))
 
     def test_find_all_do_not_find_var_val_none(self):
         self.add_voicemail_zonemessages_settings(var_name='setting1',
@@ -54,7 +54,7 @@ class TestFindAll(DAOTestCase):
 
         voicemail_zonemessages = voicemail_zonemessages_dao.find_all()
 
-        assert_that(voicemail_zonemessages, contains(row2))
+        assert_that(voicemail_zonemessages, contains_exactly(row2))
 
 
 class TestEditAll(DAOTestCase):

--- a/xivo_dao/stat_call_on_queue_dao.py
+++ b/xivo_dao/stat_call_on_queue_dao.py
@@ -1,9 +1,9 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.stat_call_on_queue import StatCallOnQueue
 from xivo_dao import stat_queue_dao
-from sqlalchemy import func, between, literal
+from sqlalchemy import func, between, literal, literal_column
 from sqlalchemy.sql import text
 from sqlalchemy.sql.expression import extract, cast
 from sqlalchemy.types import Integer
@@ -101,7 +101,7 @@ def find_all_callid_between_date(session, start_date, end_date):
          from stat_call_on_queue) as foo
        where foo.end between :start_date and :end_date
     '''
-    rows = session.query('callid').from_statement(text(sql)).params(start_date=start_date, end_date=end_date)
+    rows = session.query(literal_column('callid')).from_statement(text(sql)).params(start_date=start_date, end_date=end_date)
 
     return [row[0] for row in rows]
 

--- a/xivo_dao/stat_dao.py
+++ b/xivo_dao/stat_dao.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy.sql import text
+from sqlalchemy.sql import literal_column, text
 
 _STR_TIME_FMT = "%Y-%m-%d %H:%M:%S.%f%z"
 
@@ -142,7 +142,7 @@ def _run_sql_function_returning_void(session, start, end, function):
     end = end.strftime(_STR_TIME_FMT)
 
     (session
-     .query('place_holder')
+     .query(literal_column('place_holder'))
      .from_statement(text(function))
      .params(start=start, end=end)
      .first())
@@ -176,7 +176,7 @@ SELECT stat_agent.id AS agent,
     end = end.strftime(_STR_TIME_FMT)
 
     rows = (session
-            .query('agent', 'pauseall', 'unpauseall')
+            .query(literal_column('agent'), literal_column('pauseall'), literal_column('unpauseall'))
             .from_statement(text(pause_in_range))
             .params(start=start, end=end))
 
@@ -308,9 +308,15 @@ ORDER BY
     formatted_start = start.strftime(_STR_TIME_FMT)
     formatted_end = end.strftime(_STR_TIME_FMT)
 
-    rows = (session.query('agent', 'login_timestamp', 'logout_timestamp')
-            .from_statement(text(completed_logins_query))
-            .params(start=formatted_start, end=formatted_end))
+    rows = (
+        session.query(
+            literal_column('agent'),
+            literal_column('login_timestamp'),
+            literal_column('logout_timestamp')
+        )
+        .from_statement(text(completed_logins_query))
+        .params(start=formatted_start, end=formatted_end)
+    )
 
     results = {}
 
@@ -373,9 +379,9 @@ HAVING
     end = end.strftime(_STR_TIME_FMT)
 
     rows = session.query(
-        'agent',
-        'login',
-        'logout',
+        literal_column('agent'),
+        literal_column('login'),
+        literal_column('logout'),
     ).from_statement(text(query)).params(start=start, end=end)
 
     agent_last_logins = {}

--- a/xivo_dao/tests/test_agent_dao.py
+++ b/xivo_dao/tests/test_agent_dao.py
@@ -65,7 +65,7 @@ class TestAgentDAO(DAOTestCase):
         self.assertRaises(LookupError, agent_dao.agent_with_id, agent.id, tenant_uuids=[self.default_tenant.uuid])
 
         result = agent_dao.agent_with_id(agent.id, tenant_uuids=[self.default_tenant.uuid, tenant.uuid])
-        self.assertEqual(result.id, agent.id)
+        assert result.id == agent.id
 
     def test_agent_with_number(self):
         agent = self.add_agent()

--- a/xivo_dao/tests/test_agent_dao.py
+++ b/xivo_dao/tests/test_agent_dao.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, empty, equal_to, has_properties
+from hamcrest import assert_that, contains_exactly, empty, equal_to, has_properties
 
 from xivo_dao import agent_dao
 from xivo_dao.alchemy.queuemember import QueueMember
@@ -26,14 +26,14 @@ class TestAgentDAO(DAOTestCase):
         assert_that(result, has_properties(
             id=agent.id,
             number=agent.number,
-            queues=contains(
+            queues=contains_exactly(
                 has_properties(
                     id=queue.id,
                     name=queue_member.queue_name,
                     penalty=queue_member.penalty,
                 )
             ),
-            user_ids=contains(user.id),
+            user_ids=contains_exactly(user.id),
         ))
 
     def test_agent_with_id_no_user(self):
@@ -46,7 +46,7 @@ class TestAgentDAO(DAOTestCase):
         assert_that(result, has_properties(
             id=agent.id,
             number=agent.number,
-            queues=contains(
+            queues=contains_exactly(
                 has_properties(
                     id=queue.id,
                     name=queue_member.queue_name,
@@ -76,7 +76,7 @@ class TestAgentDAO(DAOTestCase):
         assert_that(result, has_properties(
             id=agent.id,
             number=agent.number,
-            user_ids=contains(user.id),
+            user_ids=contains_exactly(user.id),
         ))
 
     def test_agent_with_number_no_user(self):
@@ -108,7 +108,7 @@ class TestAgentDAO(DAOTestCase):
 
         result = agent_dao.agent_with_user_uuid(user.uuid)
 
-        assert_that(result, has_properties(id=agent.id, user_ids=contains(user.id)))
+        assert_that(result, has_properties(id=agent.id, user_ids=contains_exactly(user.id)))
 
     def test_agent_with_user_uuid_unknown_user(self):
         self.add_agent()

--- a/xivo_dao/tests/test_agent_status_dao.py
+++ b/xivo_dao/tests/test_agent_status_dao.py
@@ -108,8 +108,8 @@ class TestAgentStatusDao(DAOTestCase):
             agent_id
         )
 
-        self.assertEqual(extension, result_extension)
-        self.assertEqual(context, result_context)
+        assert extension == result_extension
+        assert context == result_context
 
     def test_get_extension_from_agent_id_not_found(self):
         agent_id = 13
@@ -147,12 +147,12 @@ class TestAgentStatusDao(DAOTestCase):
 
         result = agent_status_dao.get_agent_id_from_extension(extension, context)
 
-        self.assertEqual(result, agent_id)
+        assert result == agent_id
 
     def test_get_status_with_unlogged_agent_returns_none(self):
         agent_id = 1
         agent_status = agent_status_dao.get_status(agent_id)
-        self.assertEqual(agent_status, None)
+        assert agent_status is None
 
     def test_get_status_with_logged_agent_returns_an_agent(self):
         agent = self.add_agent()
@@ -401,9 +401,9 @@ class TestAgentStatusDao(DAOTestCase):
 
         statuses = agent_status_dao.get_statuses(tenant_uuids=[tenant.uuid])
 
-        self.assertEqual(len(statuses), 1)
-        self.assertEqual(statuses[0].agent_id, agent.id)
-        self.assertEqual(statuses[0].tenant_uuid, tenant.uuid)
+        assert len(statuses) == 1
+        assert statuses[0].agent_id == agent.id
+        assert statuses[0].tenant_uuid == tenant.uuid
         assert_that(
             statuses,
             contains_exactly(has_properties(agent_id=agent.id, tenant_uuid=tenant.uuid)),

--- a/xivo_dao/tests/test_agent_status_dao.py
+++ b/xivo_dao/tests/test_agent_status_dao.py
@@ -1,7 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, empty, has_properties, none
+from hamcrest import assert_that, contains_exactly, empty, has_properties, none
 from xivo_dao import agent_status_dao
 from xivo_dao.tests.test_dao import DAOTestCase, UNKNOWN_UUID
 from xivo_dao.alchemy.agent_login_status import AgentLoginStatus
@@ -42,7 +42,7 @@ class TestAgentStatusDao(DAOTestCase):
                 paused=paused,
                 paused_reason=paused_reason,
                 state_interface=state_interface,
-                user_ids=contains(user.id),
+                user_ids=contains_exactly(user.id),
             ),
         )
 
@@ -169,7 +169,7 @@ class TestAgentStatusDao(DAOTestCase):
                 extension=agent_login_status.extension,
                 interface=agent_login_status.interface,
                 state_interface=agent_login_status.state_interface,
-                queues=contains(
+                queues=contains_exactly(
                     has_properties(
                         id=agent_membership.queue_id,
                         name=agent_membership.queue_name,
@@ -190,7 +190,7 @@ class TestAgentStatusDao(DAOTestCase):
             result,
             has_properties(
                 agent_id=agent.id,
-                queues=contains(has_properties(id=agent_membership.queue_id)),
+                queues=contains_exactly(has_properties(id=agent_membership.queue_id)),
             ),
         )
 
@@ -221,12 +221,12 @@ class TestAgentStatusDao(DAOTestCase):
                 context=agent_login_status.context,
                 interface=agent_login_status.interface,
                 state_interface=agent_login_status.state_interface,
-                queues=contains(
+                queues=contains_exactly(
                     has_properties(
                         id=agent_membership.queue_id, name=agent_membership.queue_name
                     )
                 ),
-                user_ids=contains(user.id),
+                user_ids=contains_exactly(user.id),
             ),
         )
 
@@ -246,7 +246,7 @@ class TestAgentStatusDao(DAOTestCase):
                 context=agent_login_status.context,
                 interface=agent_login_status.interface,
                 state_interface=agent_login_status.state_interface,
-                queues=contains(
+                queues=contains_exactly(
                     has_properties(
                         id=agent_membership.queue_id, name=agent_membership.queue_name
                     )
@@ -269,7 +269,7 @@ class TestAgentStatusDao(DAOTestCase):
             result,
             has_properties(
                 agent_id=agent.id,
-                queues=contains(has_properties(id=agent_membership.queue_id)),
+                queues=contains_exactly(has_properties(id=agent_membership.queue_id)),
             ),
         )
 
@@ -315,12 +315,12 @@ class TestAgentStatusDao(DAOTestCase):
                 context=agent_login_status.context,
                 interface=agent_login_status.interface,
                 state_interface=agent_login_status.state_interface,
-                queues=contains(
+                queues=contains_exactly(
                     has_properties(
                         id=agent_membership.queue_id, name=agent_membership.queue_name
                     )
                 ),
-                user_ids=contains(user.id),
+                user_ids=contains_exactly(user.id),
             ),
         )
 
@@ -339,7 +339,7 @@ class TestAgentStatusDao(DAOTestCase):
             result,
             has_properties(
                 agent_id=agent.id,
-                queues=contains(has_properties(id=agent_membership.queue_id)),
+                queues=contains_exactly(has_properties(id=agent_membership.queue_id)),
             ),
         )
 
@@ -362,7 +362,7 @@ class TestAgentStatusDao(DAOTestCase):
 
         assert_that(
             statuses,
-            contains(
+            contains_exactly(
                 has_properties(
                     agent_id=agent.id,
                     agent_number=agent.number,
@@ -382,7 +382,7 @@ class TestAgentStatusDao(DAOTestCase):
 
         assert_that(
             statuses,
-            contains(
+            contains_exactly(
                 has_properties(
                     agent_id=agent.id,
                     agent_number=agent.number,
@@ -406,7 +406,7 @@ class TestAgentStatusDao(DAOTestCase):
         self.assertEqual(statuses[0].tenant_uuid, tenant.uuid)
         assert_that(
             statuses,
-            contains(has_properties(agent_id=agent.id, tenant_uuid=tenant.uuid)),
+            contains_exactly(has_properties(agent_id=agent.id, tenant_uuid=tenant.uuid)),
         )
 
         statuses = agent_status_dao.get_statuses(
@@ -424,7 +424,7 @@ class TestAgentStatusDao(DAOTestCase):
 
         assert_that(
             statuses,
-            contains(
+            contains_exactly(
                 has_properties(
                     agent_id=agent.id,
                     agent_number=agent.number,
@@ -453,7 +453,7 @@ class TestAgentStatusDao(DAOTestCase):
 
         assert_that(
             statuses,
-            contains(has_properties(agent_id=agent1.id, agent_number=agent1.number)),
+            contains_exactly(has_properties(agent_id=agent1.id, agent_number=agent1.number)),
         )
 
     def test_get_statuses_to_remove_from_queue(self):
@@ -473,7 +473,7 @@ class TestAgentStatusDao(DAOTestCase):
 
         assert_that(
             statuses,
-            contains(has_properties(agent_id=agent1.id, agent_number=agent1.number)),
+            contains_exactly(has_properties(agent_id=agent1.id, agent_number=agent1.number)),
         )
 
     def test_get_logged_agent_ids(self):
@@ -483,7 +483,7 @@ class TestAgentStatusDao(DAOTestCase):
 
         agent_ids = agent_status_dao.get_logged_agent_ids()
 
-        assert_that(agent_ids, contains(agent_id))
+        assert_that(agent_ids, contains_exactly(agent_id))
 
     def test_get_logged_agent_ids_multi_tenant(self):
         tenant = self.add_tenant()
@@ -491,12 +491,12 @@ class TestAgentStatusDao(DAOTestCase):
         self._insert_agent_login_status(agent.id, agent.number)
 
         agent_ids = agent_status_dao.get_logged_agent_ids(tenant_uuids=[tenant.uuid])
-        assert_that(agent_ids, contains(agent.id))
+        assert_that(agent_ids, contains_exactly(agent.id))
 
         agent_ids = agent_status_dao.get_logged_agent_ids(
             tenant_uuids=[self.default_tenant.uuid, tenant.uuid],
         )
-        assert_that(agent_ids, contains(agent.id))
+        assert_that(agent_ids, contains_exactly(agent.id))
 
         agent_ids = agent_status_dao.get_logged_agent_ids(
             tenant_uuids=[self.default_tenant.uuid]
@@ -534,7 +534,7 @@ class TestAgentStatusDao(DAOTestCase):
         memberships = self.session.query(AgentMembershipStatus).all()
         assert_that(
             memberships,
-            contains(
+            contains_exactly(
                 has_properties(
                     queue_id=queue1.id, queue_name=queue1.name, penalty=queue1.penalty
                 ),
@@ -571,7 +571,7 @@ class TestAgentStatusDao(DAOTestCase):
         assert_that(
             agent1_status,
             has_properties(
-                queues=contains(
+                queues=contains_exactly(
                     has_properties(id=1, name='queue1'),
                     has_properties(id=2, name='queue2'),
                 )
@@ -581,7 +581,7 @@ class TestAgentStatusDao(DAOTestCase):
         assert_that(
             agent2_status,
             has_properties(
-                queues=contains(
+                queues=contains_exactly(
                     has_properties(id=1, name='queue1'),
                     has_properties(id=2, name='queue2'),
                 )
@@ -610,7 +610,7 @@ class TestAgentStatusDao(DAOTestCase):
         memberships = self.session.query(AgentMembershipStatus).all()
         assert_that(
             memberships,
-            contains(
+            contains_exactly(
                 has_properties(queue_id=2, queue_name='queue2', agent_id=agent.id),
             ),
         )
@@ -639,7 +639,7 @@ class TestAgentStatusDao(DAOTestCase):
         memberships = self.session.query(AgentMembershipStatus).all()
         assert_that(
             memberships,
-            contains(
+            contains_exactly(
                 has_properties(queue_id=queue2_id, queue_name=queue2_name),
             ),
         )
@@ -662,7 +662,7 @@ class TestAgentStatusDao(DAOTestCase):
                 AgentMembershipStatus.agent_id == agent_id,
             )
         )
-        assert_that(memberships, contains(has_properties(penalty=queue_penalty_after)))
+        assert_that(memberships, contains_exactly(has_properties(penalty=queue_penalty_after)))
 
     def test_update_pause_status(self):
         agent_number = '1000'

--- a/xivo_dao/tests/test_asterisk_conf_dao.py
+++ b/xivo_dao/tests/test_asterisk_conf_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from hamcrest import (
     all_of,
     assert_that,
-    contains,
+    contains_exactly,
     contains_inanyorder,
     empty,
     equal_to,
@@ -119,7 +119,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
 
         sccp_line = asterisk_conf_dao.find_sccp_line_settings()
 
-        assert_that(sccp_line, contains())
+        assert_that(sccp_line, contains_exactly())
 
     def test_find_sccp_line_allow(self):
         number = '1234'
@@ -134,7 +134,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
 
         assert_that(
             sccp_lines,
-            contains(
+            contains_exactly(
                 has_entries(
                     user_id=ule.user_id,
                     name=sccp_line.name,
@@ -162,7 +162,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
 
         assert_that(
             sccp_lines,
-            contains(
+            contains_exactly(
                 has_entries(
                     user_id=ule.user_id,
                     name=sccp_line.name,
@@ -195,7 +195,7 @@ class TestSCCPLineSettingDAO(DAOTestCase, PickupHelperMixin):
 
         assert_that(
             sccp_lines,
-            contains(
+            contains_exactly(
                 has_entries(
                     user_id=ule.user_id,
                     name=sccp_line.name,
@@ -241,7 +241,7 @@ class TestSccpConfDAO(DAOTestCase):
 
         assert_that(
             sccp_devices,
-            contains(
+            contains_exactly(
                 has_entries(
                     id=sccp_device.id,
                     name=sccp_device.name,
@@ -265,7 +265,7 @@ class TestSccpConfDAO(DAOTestCase):
 
         assert_that(
             sccp_devices,
-            contains(
+            contains_exactly(
                 has_entries(
                     id=sccp_device.id,
                     name=sccp_device.name,
@@ -285,7 +285,7 @@ class TestFindSccpSpeeddialSettings(DAOTestCase):
     def test_given_no_func_key_then_returns_empty_list(self):
         result = asterisk_conf_dao.find_sccp_speeddial_settings()
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_custom_func_key_then_returns_converted_func_key(self):
         exten = '1000'
@@ -302,7 +302,7 @@ class TestFindSccpSpeeddialSettings(DAOTestCase):
 
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     user_id=user_row.id,
                     fknum=func_key_mapping_row.position,
@@ -326,7 +326,7 @@ class TestFindSccpSpeeddialSettings(DAOTestCase):
 
         result = asterisk_conf_dao.find_sccp_speeddial_settings()
 
-        assert_that(result, contains(has_entries(exten='2000', label='hello')))
+        assert_that(result, contains_exactly(has_entries(exten='2000', label='hello')))
 
     def add_user_with_sccp_device(self, exten, context):
         user_row = self.add_user()
@@ -381,7 +381,7 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
 
         pickup_members = asterisk_conf_dao.find_pickup_members('sip')
 
-        assert_that(pickup_members, contains())
+        assert_that(pickup_members, contains_exactly())
 
     def test_find_pickup_members_with_sip_users(self):
         pickup = self.add_pickup()
@@ -591,7 +591,7 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
 
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     exten='12',
                     commented=0,
@@ -614,7 +614,7 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
 
         result = asterisk_conf_dao.find_exten_settings(default_context.name)
 
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_find_exten_settings_multiple_extensions(self):
         context = self.add_context()
@@ -716,7 +716,7 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
 
         assert_that(
             voicemails,
-            contains(
+            contains_exactly(
                 has_entries(
                     uniqueid=vm.uniqueid,
                     deletevoicemail=0,
@@ -1042,9 +1042,9 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
         assert_that(
             result,
             contains_inanyorder(
-                contains('Local/100@default', '1', '', ''),
-                contains('PJSIP/3m6dsc', '5', '', ''),
-                contains('SCCP/1003', '15', '', ''),
+                contains_exactly('Local/100@default', '1', '', ''),
+                contains_exactly('PJSIP/3m6dsc', '5', '', ''),
+                contains_exactly('SCCP/1003', '15', '', ''),
             ),
         )
 
@@ -1064,7 +1064,7 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
         assert_that(
             result,
             contains_inanyorder(
-                contains(
+                contains_exactly(
                     f'Local/{user.uuid}@usersharedlines',
                     '0',
                     '',
@@ -1192,18 +1192,18 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
 
     def test_given_no_sip_accounts_then_returns_empty_list(self):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_sip_account_is_not_associated_then_returns_empty_list(self):
         self.add_endpoint_sip(template=False)
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_sip_account_is_associated_to_trunk_then_returns_empty_list(self):
         endpoint = self.add_endpoint_sip(template=False)
         self.add_trunk(endpoint_sip_uuid=endpoint.uuid)
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_no_endpoint_on_the_meeting_return_empty_list(self):
         self.add_meeting()
@@ -1236,33 +1236,33 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
                     name=endpoint.name,
                     label=endpoint.label,
                     aor_section_options=has_items(
-                        contains('qualify_frequency', '60'),
-                        contains('maximum_expiration', '3600'),
-                        contains('minimum_expiration', '60'),
-                        contains('default_expiration', '120'),
-                        contains('max_contacts', '50'),
-                        contains('remove_existing', 'false'),
+                        contains_exactly('qualify_frequency', '60'),
+                        contains_exactly('maximum_expiration', '3600'),
+                        contains_exactly('minimum_expiration', '60'),
+                        contains_exactly('default_expiration', '120'),
+                        contains_exactly('max_contacts', '50'),
+                        contains_exactly('remove_existing', 'false'),
                     ),
                     auth_section_options=has_items(
-                        contains('username', 'iddqd'),
-                        contains('password', 'idbehold'),
+                        contains_exactly('username', 'iddqd'),
+                        contains_exactly('password', 'idbehold'),
                     ),
                     endpoint_section_options=has_items(
-                        contains('allow', '!all,ulaw'),
-                        contains('allow_subscribe', 'yes'),
-                        contains('allow_transfer', 'yes'),
-                        contains('use_ptime', 'yes'),
-                        contains('rtp_timeout', '7200'),
-                        contains('rtp_timeout_hold', '0'),
-                        contains('timers_sess_expires', '600'),
-                        contains('timers_min_se', '90'),
-                        contains('trust_id_inbound', 'yes'),
-                        contains('dtmf_mode', 'rfc4733'),
-                        contains('send_rpid', 'yes'),
-                        contains('inband_progress', 'no'),
-                        contains('direct_media', 'no'),
-                        contains('callerid', '"Foo Bar" <101>'),
-                        contains('webrtc', 'yes'),
+                        contains_exactly('allow', '!all,ulaw'),
+                        contains_exactly('allow_subscribe', 'yes'),
+                        contains_exactly('allow_transfer', 'yes'),
+                        contains_exactly('use_ptime', 'yes'),
+                        contains_exactly('rtp_timeout', '7200'),
+                        contains_exactly('rtp_timeout_hold', '0'),
+                        contains_exactly('timers_sess_expires', '600'),
+                        contains_exactly('timers_min_se', '90'),
+                        contains_exactly('trust_id_inbound', 'yes'),
+                        contains_exactly('dtmf_mode', 'rfc4733'),
+                        contains_exactly('send_rpid', 'yes'),
+                        contains_exactly('inband_progress', 'no'),
+                        contains_exactly('direct_media', 'no'),
+                        contains_exactly('callerid', '"Foo Bar" <101>'),
+                        contains_exactly('webrtc', 'yes'),
                     ),
                 ),
             ),
@@ -1283,10 +1283,10 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('transport', transport.name),
+                        contains_exactly('transport', transport.name),
                     ),
                 )
             ),
@@ -1305,11 +1305,11 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         # inherited from the webrtc template
-                        contains('transport', 'transport-wss'),
+                        contains_exactly('transport', 'transport-wss'),
                     ),
                 )
             ),
@@ -1326,10 +1326,10 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains(
+                        contains_exactly(
                             'set_var',
                             f'XIVO_ORIGINAL_CALLER_ID={caller_id}',
                         ),
@@ -1345,7 +1345,7 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         ['set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'],
@@ -1361,7 +1361,7 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         ['set_var', f'__WAZO_TENANT_UUID={endpoint.tenant_uuid}'],
@@ -1381,18 +1381,18 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     aor_section_options=has_items(
-                        contains('type', 'aor'),
+                        contains_exactly('type', 'aor'),
                     ),
                     auth_section_options=has_items(
-                        contains('type', 'auth'),
+                        contains_exactly('type', 'auth'),
                     ),
                     endpoint_section_options=has_items(
-                        contains('type', 'endpoint'),
-                        contains('auth', endpoint.name),
-                        contains('aors', endpoint.name),
+                        contains_exactly('type', 'endpoint'),
+                        contains_exactly('auth', endpoint.name),
+                        contains_exactly('aors', endpoint.name),
                     ),
                 )
             ),
@@ -1419,19 +1419,19 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_meeting_guests_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=contains_inanyorder(
-                        contains('type', 'endpoint'),  # only showed once
-                        contains('codecs', '!all,ulaw'),
-                        contains('webrtc', 'true'),  # only showed once
-                        contains(
+                        contains_exactly('type', 'endpoint'),  # only showed once
+                        contains_exactly('codecs', '!all,ulaw'),
+                        contains_exactly('webrtc', 'true'),  # only showed once
+                        contains_exactly(
                             'set_var', f'__WAZO_TENANT_UUID={endpoint.tenant_uuid}'
                         ),
-                        contains('set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'),
-                        contains('set_var', f'WAZO_MEETING_UUID={meeting.uuid}'),
-                        contains('set_var', f'WAZO_MEETING_NAME={meeting.name}'),
-                        contains('context', self.context.name),
+                        contains_exactly('set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'),
+                        contains_exactly('set_var', f'WAZO_MEETING_UUID={meeting.uuid}'),
+                        contains_exactly('set_var', f'WAZO_MEETING_NAME={meeting.name}'),
+                        contains_exactly('context', self.context.name),
                     )
                 )
             ),
@@ -1454,19 +1454,19 @@ class TestFindSipMeetingGuestsSettings(BaseFindSIPSettings):
         assert_that(
             result,
             all_of(
-                contains(
+                contains_exactly(
                     has_entries(
                         endpoint_section_options=has_items(
-                            contains('type', 'endpoint'),
-                            contains('webrtc', 'no'),  # From the endpoint
+                            contains_exactly('type', 'endpoint'),
+                            contains_exactly('webrtc', 'no'),  # From the endpoint
                         )
                     )
                 ),
                 not_(
-                    contains(
+                    contains_exactly(
                         has_entries(
                             endpoint_section_options=has_items(
-                                contains('webrtc', 'yes'),  # From the template
+                                contains_exactly('webrtc', 'yes'),  # From the template
                             )
                         )
                     ),
@@ -1497,18 +1497,18 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
 
     def test_given_no_sip_accounts_then_returns_empty_list(self):
         result = asterisk_conf_dao.find_sip_user_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_sip_account_is_not_associated_then_returns_empty_list(self):
         self.add_endpoint_sip(template=False)
         result = asterisk_conf_dao.find_sip_user_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_sip_account_is_associated_to_trunk_then_returns_empty_list(self):
         endpoint = self.add_endpoint_sip(template=False)
         self.add_trunk(endpoint_sip_uuid=endpoint.uuid)
         result = asterisk_conf_dao.find_sip_user_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_that_templates_are_included(self):
         endpoint = self.add_endpoint_sip(
@@ -1533,33 +1533,33 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
                     name=endpoint.name,
                     label=endpoint.label,
                     aor_section_options=has_items(
-                        contains('qualify_frequency', '60'),
-                        contains('maximum_expiration', '3600'),
-                        contains('minimum_expiration', '60'),
-                        contains('default_expiration', '120'),
-                        contains('max_contacts', '10'),
-                        contains('remove_existing', 'false'),
+                        contains_exactly('qualify_frequency', '60'),
+                        contains_exactly('maximum_expiration', '3600'),
+                        contains_exactly('minimum_expiration', '60'),
+                        contains_exactly('default_expiration', '120'),
+                        contains_exactly('max_contacts', '10'),
+                        contains_exactly('remove_existing', 'false'),
                     ),
                     auth_section_options=has_items(
-                        contains('username', 'iddqd'),
-                        contains('password', 'idbehold'),
+                        contains_exactly('username', 'iddqd'),
+                        contains_exactly('password', 'idbehold'),
                     ),
                     endpoint_section_options=has_items(
-                        contains('allow', '!all,ulaw'),
-                        contains('allow_subscribe', 'yes'),
-                        contains('allow_transfer', 'yes'),
-                        contains('use_ptime', 'yes'),
-                        contains('rtp_timeout', '7200'),
-                        contains('rtp_timeout_hold', '0'),
-                        contains('timers_sess_expires', '600'),
-                        contains('timers_min_se', '90'),
-                        contains('trust_id_inbound', 'yes'),
-                        contains('dtmf_mode', 'rfc4733'),
-                        contains('send_rpid', 'yes'),
-                        contains('inband_progress', 'no'),
-                        contains('direct_media', 'no'),
-                        contains('callerid', '"Foo Bar" <101>'),
-                        contains('webrtc', 'yes'),
+                        contains_exactly('allow', '!all,ulaw'),
+                        contains_exactly('allow_subscribe', 'yes'),
+                        contains_exactly('allow_transfer', 'yes'),
+                        contains_exactly('use_ptime', 'yes'),
+                        contains_exactly('rtp_timeout', '7200'),
+                        contains_exactly('rtp_timeout_hold', '0'),
+                        contains_exactly('timers_sess_expires', '600'),
+                        contains_exactly('timers_min_se', '90'),
+                        contains_exactly('trust_id_inbound', 'yes'),
+                        contains_exactly('dtmf_mode', 'rfc4733'),
+                        contains_exactly('send_rpid', 'yes'),
+                        contains_exactly('inband_progress', 'no'),
+                        contains_exactly('direct_media', 'no'),
+                        contains_exactly('callerid', '"Foo Bar" <101>'),
+                        contains_exactly('webrtc', 'yes'),
                     ),
                 ),
             ),
@@ -1572,10 +1572,10 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('context', self.context.name)
+                        contains_exactly('context', self.context.name)
                     ),
                 )
             ),
@@ -1593,11 +1593,11 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('context', f'stasis-wazo-app-{application.uuid}'),
-                        contains('set_var', f'TRANSFER_CONTEXT={self.context.name}'),
+                        contains_exactly('context', f'stasis-wazo-app-{application.uuid}'),
+                        contains_exactly('set_var', f'TRANSFER_CONTEXT={self.context.name}'),
                     )
                 )
             ),
@@ -1610,10 +1610,10 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('set_var', f'TRANSFER_CONTEXT={self.context.name}'),
+                        contains_exactly('set_var', f'TRANSFER_CONTEXT={self.context.name}'),
                     ),
                 )
             ),
@@ -1631,10 +1631,10 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('transport', transport.name),
+                        contains_exactly('transport', transport.name),
                     ),
                 )
             ),
@@ -1650,11 +1650,11 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         # inherited from the webrtc template
-                        contains('transport', 'transport-wss'),
+                        contains_exactly('transport', 'transport-wss'),
                     ),
                 )
             ),
@@ -1669,10 +1669,10 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains(
+                        contains_exactly(
                             'set_var',
                             f'PICKUPMARK={extension.exten}%{extension.context}',
                         ),
@@ -1692,15 +1692,15 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     aor_section_options=has_items(
-                        contains(
+                        contains_exactly(
                             'mailboxes', f'{voicemail.number}@{voicemail.context}'
                         ),
                     ),
                     endpoint_section_options=has_items(
-                        contains(
+                        contains_exactly(
                             'mailboxes', f'{voicemail.number}@{voicemail.context}'
                         ),
                     ),
@@ -1719,10 +1719,10 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains(
+                        contains_exactly(
                             'set_var',
                             f'XIVO_ORIGINAL_CALLER_ID={caller_id}',
                         ),
@@ -1738,7 +1738,7 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         ['set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'],
@@ -1756,7 +1756,7 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         ['set_var', f'XIVO_USERID={user.id}'],  # Deprecated in 24.01
@@ -1775,7 +1775,7 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         ['set_var', f'XIVO_USERUUID={user.uuid}'],   # Deprecated in 24.01
@@ -1792,7 +1792,7 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         ['set_var', f'__WAZO_TENANT_UUID={endpoint.tenant_uuid}'],
@@ -1810,7 +1810,7 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
                         ['set_var', f'WAZO_LINE_ID={line.id}'],
@@ -1830,18 +1830,18 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     aor_section_options=has_items(
-                        contains('type', 'aor'),
+                        contains_exactly('type', 'aor'),
                     ),
                     auth_section_options=has_items(
-                        contains('type', 'auth'),
+                        contains_exactly('type', 'auth'),
                     ),
                     endpoint_section_options=has_items(
-                        contains('type', 'endpoint'),
-                        contains('auth', endpoint.name),
-                        contains('aors', endpoint.name),
+                        contains_exactly('type', 'endpoint'),
+                        contains_exactly('auth', endpoint.name),
+                        contains_exactly('aors', endpoint.name),
                     ),
                 )
             ),
@@ -1912,19 +1912,19 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         result = asterisk_conf_dao.find_sip_user_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=contains_inanyorder(
-                        contains('type', 'endpoint'),  # only showed once
-                        contains('codecs', '!all,ulaw'),
-                        contains('webrtc', 'true'),  # only showed once
-                        contains(
+                        contains_exactly('type', 'endpoint'),  # only showed once
+                        contains_exactly('codecs', '!all,ulaw'),
+                        contains_exactly('webrtc', 'true'),  # only showed once
+                        contains_exactly(
                             'set_var', f'__WAZO_TENANT_UUID={endpoint.tenant_uuid}'
                         ),
-                        contains('set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'),
-                        contains('set_var', f'WAZO_LINE_ID={line.id}'),
-                        contains('context', self.context.name),
-                        contains('set_var', f'TRANSFER_CONTEXT={self.context.name}'),
+                        contains_exactly('set_var', 'WAZO_CHANNEL_DIRECTION=from-wazo'),
+                        contains_exactly('set_var', f'WAZO_LINE_ID={line.id}'),
+                        contains_exactly('context', self.context.name),
+                        contains_exactly('set_var', f'TRANSFER_CONTEXT={self.context.name}'),
                     )
                 )
             ),
@@ -1947,19 +1947,19 @@ class TestFindSipUserSettings(BaseFindSIPSettings, PickupHelperMixin):
         assert_that(
             result,
             all_of(
-                contains(
+                contains_exactly(
                     has_entries(
                         endpoint_section_options=has_items(
-                            contains('type', 'endpoint'),
-                            contains('webrtc', 'no'),  # From the endpoint
+                            contains_exactly('type', 'endpoint'),
+                            contains_exactly('webrtc', 'no'),  # From the endpoint
                         )
                     )
                 ),
                 not_(
-                    contains(
+                    contains_exactly(
                         has_entries(
                             endpoint_section_options=has_items(
-                                contains('webrtc', 'yes'),  # From the template
+                                contains_exactly('webrtc', 'yes'),  # From the template
                             )
                         )
                     ),
@@ -2003,23 +2003,23 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
 
     def test_given_no_sip_accounts_then_returns_empty_list(self):
         result = asterisk_conf_dao.find_sip_trunk_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_sip_account_is_not_category_user_then_returns_empty_list(self):
         self.add_endpoint_sip(template=False)
         result = asterisk_conf_dao.find_sip_trunk_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_sip_account_is_deactivated_then_returns_empty_list(self):
         self.add_endpoint_sip(template=False)
         result = asterisk_conf_dao.find_sip_trunk_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_given_sip_account_is_associated_to_a_line_then_returns_empty_list(self):
         endpoint = self.add_endpoint_sip(template=False)
         self.add_line(endpoint_sip_uuid=endpoint.uuid)
         result = asterisk_conf_dao.find_sip_trunk_settings()
-        assert_that(result, contains())
+        assert_that(result, contains_exactly())
 
     def test_that_templates_are_included(self):
         endpoint = self.add_endpoint_sip(
@@ -2047,48 +2047,48 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
                     name=endpoint.name,
                     label=endpoint.label,
                     aor_section_options=has_items(
-                        contains('qualify_frequency', '60'),
-                        contains('maximum_expiration', '3600'),
-                        contains('minimum_expiration', '60'),
-                        contains('default_expiration', '120'),
-                        contains('max_contacts', '1'),
-                        contains('remove_existing', 'true'),
+                        contains_exactly('qualify_frequency', '60'),
+                        contains_exactly('maximum_expiration', '3600'),
+                        contains_exactly('minimum_expiration', '60'),
+                        contains_exactly('default_expiration', '120'),
+                        contains_exactly('max_contacts', '1'),
+                        contains_exactly('remove_existing', 'true'),
                     ),
                     auth_section_options=has_items(
-                        contains('username', 'iddqd'),
-                        contains('password', 'idbehold'),
+                        contains_exactly('username', 'iddqd'),
+                        contains_exactly('password', 'idbehold'),
                     ),
                     endpoint_section_options=has_items(
-                        contains('allow', '!all,ulaw'),
-                        contains('allow_subscribe', 'yes'),
-                        contains('allow_transfer', 'yes'),
-                        contains('use_ptime', 'yes'),
-                        contains('rtp_timeout', '7200'),
-                        contains('rtp_timeout_hold', '0'),
-                        contains('timers_sess_expires', '600'),
-                        contains('timers_min_se', '90'),
-                        contains('trust_id_inbound', 'yes'),
-                        contains('dtmf_mode', 'rfc4733'),
-                        contains('send_rpid', 'yes'),
-                        contains('inband_progress', 'no'),
-                        contains('direct_media', 'no'),
-                        contains('callerid', '"Foo Bar" <101>'),
+                        contains_exactly('allow', '!all,ulaw'),
+                        contains_exactly('allow_subscribe', 'yes'),
+                        contains_exactly('allow_transfer', 'yes'),
+                        contains_exactly('use_ptime', 'yes'),
+                        contains_exactly('rtp_timeout', '7200'),
+                        contains_exactly('rtp_timeout_hold', '0'),
+                        contains_exactly('timers_sess_expires', '600'),
+                        contains_exactly('timers_min_se', '90'),
+                        contains_exactly('trust_id_inbound', 'yes'),
+                        contains_exactly('dtmf_mode', 'rfc4733'),
+                        contains_exactly('send_rpid', 'yes'),
+                        contains_exactly('inband_progress', 'no'),
+                        contains_exactly('direct_media', 'no'),
+                        contains_exactly('callerid', '"Foo Bar" <101>'),
                     ),
                     identify_section_options=has_items(
-                        contains('match', '54.172.60.0'),
-                        contains('match', '54.172.60.1'),
-                        contains('match', '54.172.60.2'),
+                        contains_exactly('match', '54.172.60.0'),
+                        contains_exactly('match', '54.172.60.1'),
+                        contains_exactly('match', '54.172.60.2'),
                     ),
                     registration_section_options=has_items(
-                        contains('outbound_auth', f'auth_reg_{endpoint.name}'),
-                        contains('retry_interval', '20'),
-                        contains('auth_rejection_permanent', 'off'),
-                        contains('forbidden_retry_interval', '30'),
-                        contains('fatal_retry_interval', '30'),
-                        contains('max_retries', '10000'),
+                        contains_exactly('outbound_auth', f'auth_reg_{endpoint.name}'),
+                        contains_exactly('retry_interval', '20'),
+                        contains_exactly('auth_rejection_permanent', 'off'),
+                        contains_exactly('forbidden_retry_interval', '30'),
+                        contains_exactly('fatal_retry_interval', '30'),
+                        contains_exactly('max_retries', '10000'),
                     ),
                     registration_outbound_auth_section_options=has_items(
-                        contains('username', 'outbound_reg_username'),
+                        contains_exactly('username', 'outbound_reg_username'),
                     ),
                     outbound_auth_section_options=has_items(),
                 ),
@@ -2102,10 +2102,10 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_trunk_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('context', self.context.name)
+                        contains_exactly('context', self.context.name)
                     ),
                 )
             ),
@@ -2123,10 +2123,10 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_trunk_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('transport', transport.name),
+                        contains_exactly('transport', transport.name),
                     ),
                 )
             ),
@@ -2141,10 +2141,10 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_trunk_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     registration_section_options=has_items(
-                        contains('endpoint', endpoint.name),
+                        contains_exactly('endpoint', endpoint.name),
                     )
                 )
             ),
@@ -2166,10 +2166,10 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_trunk_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=has_items(
-                        contains('transport', transport.name),
+                        contains_exactly('transport', transport.name),
                     ),
                 )
             ),
@@ -2194,40 +2194,40 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_trunk_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     aor_section_options=has_items(
-                        contains('type', 'aor'),
-                        contains('contact', 'sip:name@proxy:port'),
+                        contains_exactly('type', 'aor'),
+                        contains_exactly('contact', 'sip:name@proxy:port'),
                     ),
                     auth_section_options=has_items(
-                        contains('type', 'auth'),
-                        contains('username', 'username'),
+                        contains_exactly('type', 'auth'),
+                        contains_exactly('username', 'username'),
                     ),
                     endpoint_section_options=has_items(
-                        contains('type', 'endpoint'),
-                        contains('aors', endpoint.name),
-                        contains('auth', endpoint.name),
-                        contains('identify_by', 'auth_username,username'),
-                        contains('outbound_auth', f'outbound_auth_{endpoint.name}'),
+                        contains_exactly('type', 'endpoint'),
+                        contains_exactly('aors', endpoint.name),
+                        contains_exactly('auth', endpoint.name),
+                        contains_exactly('identify_by', 'auth_username,username'),
+                        contains_exactly('outbound_auth', f'outbound_auth_{endpoint.name}'),
                     ),
                     registration_section_options=has_items(
-                        contains('type', 'registration'),
-                        contains('expiration', '120'),
-                        contains('outbound_auth', f'auth_reg_{endpoint.name}'),
+                        contains_exactly('type', 'registration'),
+                        contains_exactly('expiration', '120'),
+                        contains_exactly('outbound_auth', f'auth_reg_{endpoint.name}'),
                     ),
                     registration_outbound_auth_section_options=has_items(
-                        contains('type', 'auth'),
-                        contains('password', 'secret'),
+                        contains_exactly('type', 'auth'),
+                        contains_exactly('password', 'secret'),
                     ),
                     identify_section_options=has_items(
-                        contains('type', 'identify'),
-                        contains('match', '192.168.1.1'),
-                        contains('endpoint', endpoint.name),
+                        contains_exactly('type', 'identify'),
+                        contains_exactly('match', '192.168.1.1'),
+                        contains_exactly('endpoint', endpoint.name),
                     ),
                     outbound_auth_section_options=has_items(
-                        contains('type', 'auth'),
-                        contains('username', 'outbound'),
+                        contains_exactly('type', 'auth'),
+                        contains_exactly('username', 'outbound'),
                     ),
                 )
             ),
@@ -2264,7 +2264,7 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         assert_that(
             result,
             not_(
-                contains(
+                contains_exactly(
                     has_entries(
                         endpoint_section_options=has_items(
                             ['aors', template.name],
@@ -2298,13 +2298,13 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         result = asterisk_conf_dao.find_sip_trunk_settings()
         assert_that(
             result,
-            contains(
+            contains_exactly(
                 has_entries(
                     endpoint_section_options=contains_inanyorder(
-                        contains('type', 'endpoint'),  # only showed once
-                        contains('codecs', '!all,ulaw'),
-                        contains('webrtc', 'true'),  # only showed once
-                        contains(
+                        contains_exactly('type', 'endpoint'),  # only showed once
+                        contains_exactly('codecs', '!all,ulaw'),
+                        contains_exactly('webrtc', 'true'),  # only showed once
+                        contains_exactly(
                             'set_var', f'__WAZO_TENANT_UUID={endpoint.tenant_uuid}'
                         ),
                     )
@@ -2329,19 +2329,19 @@ class TestFindSipTrunkSettings(BaseFindSIPSettings):
         assert_that(
             result,
             all_of(
-                contains(
+                contains_exactly(
                     has_entries(
                         endpoint_section_options=has_items(
-                            contains('type', 'endpoint'),
-                            contains('webrtc', 'no'),  # From the endpoint
+                            contains_exactly('type', 'endpoint'),
+                            contains_exactly('webrtc', 'no'),  # From the endpoint
                         )
                     )
                 ),
                 not_(
-                    contains(
+                    contains_exactly(
                         has_entries(
                             endpoint_section_options=has_items(
-                                contains('webrtc', 'yes'),  # From the template
+                                contains_exactly('webrtc', 'yes'),  # From the template
                             )
                         )
                     ),

--- a/xivo_dao/tests/test_callfilter_dao.py
+++ b/xivo_dao/tests/test_callfilter_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao import callfilter_dao
@@ -33,7 +33,7 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
     def test_given_no_secretaries_then_returns_empty_list(self):
         result = callfilter_dao.get_secretaries_id_by_context(self.default_context.name)
 
-        self.assertEqual(result, [])
+        assert result == []
 
     def test_given_boss_then_returns_empty_list(self):
         call_filter = self.add_call_filter()
@@ -41,7 +41,7 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get_secretaries_id_by_context(self.context.name)
 
-        self.assertEqual(result, [])
+        assert result == []
 
     def test_given_one_secretary_then_returns_list_with_id(self):
         call_filter = self.add_call_filter()
@@ -51,7 +51,7 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get_secretaries_id_by_context(self.context.name)
 
-        self.assertEqual(len(result), 1)
+        assert len(result) == 1
         self.assertIn((member.id,), result)
 
     def test_given_two_secretaries_then_returns_list_with_both_ids(self):
@@ -65,7 +65,7 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get_secretaries_id_by_context(self.context.name)
 
-        self.assertEqual(len(result), 2)
+        assert len(result) == 2
         self.assertIn((first_member.id,), result)
         self.assertIn((second_member.id,), result)
 
@@ -89,7 +89,7 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get_secretaries_id_by_context(self.context.name)
 
-        self.assertEqual(len(result), 1)
+        assert len(result) == 1
         self.assertIn((member.id,), result)
 
     def test_given_user_with_multiple_line_then_returns_list_with_one_id(self):
@@ -113,7 +113,7 @@ class TestGetSecretariesIdByContext(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get_secretaries_id_by_context(self.context.name)
 
-        self.assertEqual(len(result), 1)
+        assert len(result) == 1
         self.assertIn((member.id,), result)
 
 
@@ -123,14 +123,14 @@ class TestCallFilterDAO(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get(call_filter_id)
 
-        self.assertEqual(result, [])
+        assert result == []
 
     def test_get_with_filter_but_no_members(self):
         call_filter = self.add_call_filter()
 
         result = callfilter_dao.get(call_filter.id)
 
-        self.assertEqual(result, [])
+        assert result == []
 
     def test_get_with_filter_having_members(self):
         boss_id = 1
@@ -139,11 +139,11 @@ class TestCallFilterDAO(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get(call_filter.id)
 
-        self.assertEqual(1, len(result))
+        assert 1 == len(result)
         callfilter = result[0][0]
         member = result[0][1]
-        self.assertEqual(callfilter.id, call_filter.id)
-        self.assertEqual(member.typeval, str(boss_id))
+        assert callfilter.id == call_filter.id
+        assert member.typeval == str(boss_id)
 
     def test_get_with_filter_having_2_members(self):
         boss_id = 1
@@ -154,7 +154,7 @@ class TestCallFilterDAO(BaseTestCallFilterDAO):
 
         result = callfilter_dao.get(call_filter.id)
 
-        self.assertEqual(2, len(result))
+        assert 2 == len(result)
         member_ids = [int(c[1].typeval) for c in result]
         self.assertIn(boss_id, member_ids)
         self.assertIn(secretary_id, member_ids)

--- a/xivo_dao/tests/test_case.py
+++ b/xivo_dao/tests/test_case.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -7,8 +7,4 @@ import unittest
 class TestCase(unittest.TestCase):
 
     def assertNotCalled(self, callee):
-        self.assertEqual(
-            callee.call_count,
-            0,
-            f"{callee} was called {callee.call_count:d} times"
-        )
+        assert callee.call_count == 0, f"{callee} was called {callee.call_count:d} times"

--- a/xivo_dao/tests/test_context_dao.py
+++ b/xivo_dao/tests/test_context_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2007-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2007-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao import context_dao
@@ -15,4 +15,4 @@ class TestContextDAO(DAOTestCase):
 
         context = context_dao.get(context_name)
 
-        self.assertEqual(context.name, context_name)
+        assert context.name == context_name

--- a/xivo_dao/tests/test_line_dao.py
+++ b/xivo_dao/tests/test_line_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.tests.test_dao import (
@@ -28,7 +28,7 @@ class TestLineFeaturesDAO(DAOTestCase):
             EXTEN, self.context.name
         )
 
-        self.assertEqual('PJSIP/abcdef', interface)
+        assert 'PJSIP/abcdef' == interface
 
     def test_get_interface_from_exten_and_context_sccp(self):
         name = '1001'
@@ -41,7 +41,7 @@ class TestLineFeaturesDAO(DAOTestCase):
             EXTEN, self.context.name
         )
 
-        self.assertEqual('SCCP/1001', interface)
+        assert 'SCCP/1001' == interface
 
     def test_get_interface_from_exten_and_context_custom(self):
         name = 'custom/g1/12345'
@@ -54,7 +54,7 @@ class TestLineFeaturesDAO(DAOTestCase):
             EXTEN, self.context.name
         )
 
-        self.assertEqual('custom/g1/12345', interface)
+        assert 'custom/g1/12345' == interface
 
     def test_get_interface_from_exten_and_context_multiple_lines(self):
         main_exten = '1234'
@@ -79,7 +79,7 @@ class TestLineFeaturesDAO(DAOTestCase):
             second_exten, self.context.name
         )
 
-        self.assertEqual('PJSIP/idbehold', interface)
+        assert 'PJSIP/idbehold' == interface
 
     def test_get_interface_from_exten_and_context_multiple_lines_same_exten(self):
         user = self.add_user()
@@ -101,7 +101,7 @@ class TestLineFeaturesDAO(DAOTestCase):
         )
 
         expected = f'PJSIP/{main_line_name}'
-        self.assertEqual(expected, interface)
+        assert expected == interface
 
     def test_get_interface_no_matching_exten(self):
         self.assertRaises(
@@ -119,7 +119,7 @@ class TestLineFeaturesDAO(DAOTestCase):
         interface = line_dao.get_interface_from_line_id(line.id)
 
         expected = f'PJSIP/{line_name}'
-        self.assertEqual(expected, interface)
+        assert expected == interface
 
     def test_get_interface_from_line_id_sccp(self):
         line_name = '1056'
@@ -129,7 +129,7 @@ class TestLineFeaturesDAO(DAOTestCase):
         interface = line_dao.get_interface_from_line_id(line.id)
 
         expected = f'SCCP/{line_name}'
-        self.assertEqual(expected, interface)
+        assert expected == interface
 
     def test_get_interface_from_line_id_not_found(self):
         self.assertRaises(LookupError, line_dao.get_interface_from_line_id, UNKNOWN_ID)
@@ -143,13 +143,13 @@ class TestLineFeaturesDAO(DAOTestCase):
 
         exten, context = line_dao.get_main_extension_context_from_line_id(line.id)
 
-        self.assertEqual(exten, main_exten)
-        self.assertEqual(context, self.context.name)
+        assert exten == main_exten
+        assert context == self.context.name
 
     def test_get_main_extension_context_from_line_id_unknown(self):
         result = line_dao.get_main_extension_context_from_line_id(UNKNOWN_ID)
 
-        self.assertEqual(result, None)
+        assert result is None
 
     def test_get_main_extension_context_from_line_id_without_extension(self):
         sip = self.add_endpoint_sip()
@@ -157,7 +157,7 @@ class TestLineFeaturesDAO(DAOTestCase):
 
         result = line_dao.get_main_extension_context_from_line_id(line.id)
 
-        self.assertEqual(result, None)
+        assert result is None
 
     def test_get_main_extension_context_from_line_id_with_multiple_extensions(self):
         main_exten = '1234'
@@ -175,8 +175,8 @@ class TestLineFeaturesDAO(DAOTestCase):
 
         exten, context = line_dao.get_main_extension_context_from_line_id(line.id)
 
-        self.assertEqual(exten, main_exten)
-        self.assertEqual(context, self.context.name)
+        assert exten == main_exten
+        assert context == self.context.name
 
     def test_is_line_owned_by_user(self):
         user = self.add_user()
@@ -187,7 +187,7 @@ class TestLineFeaturesDAO(DAOTestCase):
 
         result = line_dao.is_line_owned_by_user(user.uuid, line.id)
 
-        self.assertEqual(result, True)
+        assert result is True
 
     def test_is_line_owned_by_user_unknown_user(self):
         sip = self.add_endpoint_sip()
@@ -195,7 +195,7 @@ class TestLineFeaturesDAO(DAOTestCase):
 
         result = line_dao.is_line_owned_by_user(UNKNOWN_UUID, line.id)
 
-        self.assertEqual(result, False)
+        assert result is False
 
     def test_is_line_owned_by_user_unknown_line(self):
         user = self.add_user()
@@ -206,7 +206,7 @@ class TestLineFeaturesDAO(DAOTestCase):
 
         result = line_dao.is_line_owned_by_user(user.uuid, UNKNOWN_ID)
 
-        self.assertEqual(result, False)
+        assert result is False
 
     def test_is_line_owned_by_user_with_multiple_lines(self):
         user = self.add_user()
@@ -222,8 +222,8 @@ class TestLineFeaturesDAO(DAOTestCase):
         main_result = line_dao.is_line_owned_by_user(user.uuid, main_line.id)
         secondary_result = line_dao.is_line_owned_by_user(user.uuid, secondary_line.id)
 
-        self.assertEqual(main_result, True)
-        self.assertEqual(secondary_result, True)
+        assert main_result is True
+        assert secondary_result is True
 
     def test_is_line_owned_by_user_with_multiple_users(self):
         main_user = self.add_user()
@@ -237,5 +237,5 @@ class TestLineFeaturesDAO(DAOTestCase):
         main_result = line_dao.is_line_owned_by_user(main_user.uuid, line.id)
         secondary_result = line_dao.is_line_owned_by_user(secondary_user.uuid, line.id)
 
-        self.assertEqual(main_result, True)
-        self.assertEqual(secondary_result, True)
+        assert main_result is True
+        assert secondary_result is True

--- a/xivo_dao/tests/test_phone_access_dao.py
+++ b/xivo_dao/tests/test_phone_access_dao.py
@@ -1,7 +1,7 @@
-# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from hamcrest import assert_that, contains, contains_inanyorder, empty
+from hamcrest import assert_that, contains_exactly, contains_inanyorder, empty
 
 from xivo_dao import phone_access_dao
 from xivo_dao.tests.test_dao import DAOTestCase
@@ -15,7 +15,7 @@ class TestPhoneAccessDao(DAOTestCase):
 
         hosts = phone_access_dao.get_authorized_subnets()
 
-        assert_that(hosts, contains(host))
+        assert_that(hosts, contains_exactly(host))
 
     def test_get_authorized_subnets_with_commented(self):
         host = '169.254.0.0/16'

--- a/xivo_dao/tests/test_queue_log_dao.py
+++ b/xivo_dao/tests/test_queue_log_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -125,7 +125,7 @@ class TestQueueLogDAO(DAOTestCase):
             },
         }
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_get_first_time(self):
         self.assertRaises(LookupError, queue_log_dao.get_first_time, self.session)
@@ -140,7 +140,7 @@ class TestQueueLogDAO(DAOTestCase):
 
         result = queue_log_dao.get_first_time(self.session)
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_get_queue_names_in_range(self):
         queue_names = sorted([f'queue_{x}' for x in range(10)])
@@ -151,7 +151,7 @@ class TestQueueLogDAO(DAOTestCase):
 
         result = sorted(queue_log_dao.get_queue_names_in_range(self.session, t - ONE_HOUR, t + ONE_HOUR))
 
-        self.assertEqual(result, queue_names)
+        assert result == queue_names
 
     def test_get_queue_abandoned_call(self):
         start = datetime(2012, 1, 1, 1, 0, 0, tzinfo=UTC)
@@ -331,30 +331,30 @@ class TestQueueLogDAO(DAOTestCase):
 
         expected = ['delete_between_1', 'delete_between_3', 'delete_between_4']
 
-        self.assertEqual(callids, expected)
+        assert callids == expected
 
     def test_insert_entry(self):
         time = datetime.now(UTC)
         queue_log_dao.insert_entry(time, 'callid', 'queue', 'agent', 'event', '1', '2', '3', '4', '5')
 
         result = [r for r in self.session.query(QueueLog).all()][0]
-        self.assertEqual(result.time, time)
-        self.assertEqual(result.callid, 'callid')
-        self.assertEqual(result.queuename, 'queue')
-        self.assertEqual(result.agent, 'agent')
-        self.assertEqual(result.event, 'event')
-        self.assertEqual(result.data1, '1')
-        self.assertEqual(result.data2, '2')
-        self.assertEqual(result.data3, '3')
-        self.assertEqual(result.data4, '4')
-        self.assertEqual(result.data5, '5')
+        assert result.time == time
+        assert result.callid == 'callid'
+        assert result.queuename == 'queue'
+        assert result.agent == 'agent'
+        assert result.event == 'event'
+        assert result.data1 == '1'
+        assert result.data2 == '2'
+        assert result.data3 == '3'
+        assert result.data4 == '4'
+        assert result.data5 == '5'
 
     def test_hours_with_calls(self):
         start = datetime(2012, 1, 1, tzinfo=UTC)
         end = datetime(2012, 6, 30, 23, 59, 59, 999999)
         res = [h for h in queue_log_dao.hours_with_calls(self.session, start, end)]
 
-        self.assertEqual(res, [])
+        assert res == []
 
         def _insert_at(t):
             queue_log_dao.insert_entry(t, 'hours', 'queue', 'agent', 'event')
@@ -371,7 +371,7 @@ class TestQueueLogDAO(DAOTestCase):
 
         res = [h for h in queue_log_dao.hours_with_calls(self.session, start, end)]
 
-        self.assertEqual(res, expected)
+        assert res == expected
 
     def test_last_callid_with_event_for_agent(self):
         t = datetime(2012, 1, 1, tzinfo=UTC)
@@ -400,7 +400,7 @@ class TestQueueLogDAO(DAOTestCase):
             agent,
         )
 
-        self.assertEqual(res, 'two')
+        assert res == 'two'
 
     def _insert_queue_log_data(self, queue_log_data):
         with flush_session(self.session):

--- a/xivo_dao/tests/test_queue_member_dao.py
+++ b/xivo_dao/tests/test_queue_member_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_dao.alchemy.queuemember import QueueMember
@@ -17,13 +17,13 @@ class TestQueueMemberDAO(DAOTestCase):
         queue_member_dao.add_agent_to_queue(agent_id, agent_number, queue_name)
 
         queue_member = self.session.query(QueueMember).first()
-        self.assertEqual(queue_member.queue_name, queue_name)
-        self.assertEqual(queue_member.interface, 'Agent/123')
-        self.assertEqual(queue_member.usertype, 'agent')
-        self.assertEqual(queue_member.userid, agent_id)
-        self.assertEqual(queue_member.channel, 'Agent')
-        self.assertEqual(queue_member.category, 'queue')
-        self.assertEqual(queue_member.position, 0)
+        assert queue_member.queue_name == queue_name
+        assert queue_member.interface == 'Agent/123'
+        assert queue_member.usertype == 'agent'
+        assert queue_member.userid == agent_id
+        assert queue_member.channel == 'Agent'
+        assert queue_member.category == 'queue'
+        assert queue_member.position == 0
 
     def test_remove_agent_from_queue(self):
         agent_id = 123
@@ -33,7 +33,7 @@ class TestQueueMemberDAO(DAOTestCase):
         queue_member_dao.remove_agent_from_queue(agent_id, queue_name)
 
         nb_queue_members = self.session.query(QueueMember).count()
-        self.assertEqual(0, nb_queue_members)
+        assert 0 == nb_queue_members
 
     def test_get_next_position_for_queue(self):
         queue_name = 'queue1'
@@ -42,7 +42,7 @@ class TestQueueMemberDAO(DAOTestCase):
 
         position = queue_member_dao._get_next_position_for_queue(self.session, queue_name)
 
-        self.assertEqual(position, 1)
+        assert position == 1
 
     def _insert_queue_member(self, queue_name, member_name, usertype='user', userid=1, is_queue=True):
         queue_member = QueueMember()

--- a/xivo_dao/tests/test_stat_agent_periodic_dao.py
+++ b/xivo_dao/tests/test_stat_agent_periodic_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime as dt
@@ -75,7 +75,7 @@ class TestStatAgentPeriodicDAO(DAOTestCase):
                       .filter(StatAgentPeriodic.time == period_start)
                       .filter(StatAgentPeriodic.stat_agent_id == agent_id_1)[0])
 
-            self.assertEqual(result.login_time, timedelta(minutes=50))
+            assert result.login_time == timedelta(minutes=50)
         except LookupError:
             self.fail('Should have found a row')
 
@@ -94,7 +94,7 @@ class TestStatAgentPeriodicDAO(DAOTestCase):
 
         total = self.session.query(func.count(StatAgentPeriodic.time))[0][0]
 
-        self.assertEqual(total, 0)
+        assert total == 0
 
     def test_remove_after(self):
         _, agent_id = self._insert_agent_to_stat_agent()
@@ -127,5 +127,5 @@ class TestStatAgentPeriodicDAO(DAOTestCase):
 
         res = self.session.query(StatAgentPeriodic.time)
 
-        self.assertEqual(res.count(), 1)
-        self.assertEqual(res[0].time, dt(2012, 1, 1, tzinfo=UTC))
+        assert res.count() == 1
+        assert res[0].time == dt(2012, 1, 1, tzinfo=UTC)

--- a/xivo_dao/tests/test_stat_call_on_queue_dao.py
+++ b/xivo_dao/tests/test_stat_call_on_queue_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime as dt
@@ -6,7 +6,7 @@ from datetime import timedelta
 from pytz import UTC
 
 from hamcrest import assert_that
-from hamcrest import contains
+from hamcrest import contains_exactly
 from sqlalchemy import func
 
 from xivo_dao import stat_call_on_queue_dao
@@ -254,7 +254,7 @@ class TestStatCallOnQueueDAO(DAOTestCase):
 
         result = stat_call_on_queue_dao.find_all_callid_between_date(self.session, start, end)
 
-        assert_that(result, contains(callid1, callid2, callid3))
+        assert_that(result, contains_exactly(callid1, callid2, callid3))
 
     def test_that_find_all_callid_between_date_includes_calls_started_before_start(self):
         callid = '234235435'
@@ -278,7 +278,7 @@ class TestStatCallOnQueueDAO(DAOTestCase):
             dt(2014, 1, 1, 11, 0, 0, tzinfo=UTC),
             dt(2014, 1, 1, 11, 59, 59, tzinfo=UTC))
 
-        assert_that(result, contains(callid))
+        assert_that(result, contains_exactly(callid))
 
     def test_remove_callid_before(self):
         callid1 = 'callid1'

--- a/xivo_dao/tests/test_stat_call_on_queue_dao.py
+++ b/xivo_dao/tests/test_stat_call_on_queue_dao.py
@@ -54,7 +54,7 @@ class TestStatCallOnQueueDAO(DAOTestCase):
 
         res = self.session.query(StatCallOnQueue).filter(StatCallOnQueue.callid == 'callid')
 
-        self.assertEqual(res[0].callid, 'callid')
+        assert res[0].callid == 'callid'
 
     def test_add_closed_call(self):
         timestamp = dt(2012, 1, 2, 0, 0, 0, tzinfo=UTC)
@@ -64,8 +64,8 @@ class TestStatCallOnQueueDAO(DAOTestCase):
 
         res = self.session.query(StatCallOnQueue).filter(StatCallOnQueue.callid == 'callid')
 
-        self.assertEqual(res[0].callid, 'callid')
-        self.assertEqual(res[0].time, timestamp)
+        assert res[0].callid == 'callid'
+        assert res[0].time == timestamp
 
     def test_add_abandoned_call(self):
         timestamp = dt(2012, 1, 2, 0, 0, 0, tzinfo=UTC)
@@ -74,9 +74,9 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         stat_call_on_queue_dao.add_abandoned_call(self.session, 'callid', timestamp, queue_name, 42)
         res = self.session.query(StatCallOnQueue).filter(StatCallOnQueue.callid == 'callid')
 
-        self.assertEqual(res[0].callid, 'callid')
-        self.assertEqual(res[0].waittime, 42)
-        self.assertEqual(res[0].time, timestamp)
+        assert res[0].callid == 'callid'
+        assert res[0].waittime == 42
+        assert res[0].time == timestamp
 
     def test_add_joinempty_call(self):
         timestamp = dt(2012, 1, 2, 0, 0, 0, tzinfo=UTC)
@@ -85,8 +85,8 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         stat_call_on_queue_dao.add_joinempty_call(self.session, 'callid', timestamp, queue_name)
         res = self.session.query(StatCallOnQueue).filter(StatCallOnQueue.callid == 'callid')
 
-        self.assertEqual(res[0].callid, 'callid')
-        self.assertEqual(res[0].time, timestamp)
+        assert res[0].callid == 'callid'
+        assert res[0].time == timestamp
 
     def test_add_leaveempty_call(self):
         timestamp = dt(2012, 1, 2, 0, 0, 0, tzinfo=UTC)
@@ -95,8 +95,8 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         stat_call_on_queue_dao.add_leaveempty_call(self.session, 'callid', timestamp, queue_name, 13)
         res = self.session.query(StatCallOnQueue).filter(StatCallOnQueue.callid == 'callid')
 
-        self.assertEqual(res[0].callid, 'callid')
-        self.assertEqual(res[0].waittime, 13)
+        assert res[0].callid == 'callid'
+        assert res[0].waittime == 13
 
     def test_add_timeout_call(self):
         timestamp = dt(2012, 1, 2, 0, 0, 0, tzinfo=UTC)
@@ -105,8 +105,8 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         stat_call_on_queue_dao.add_timeout_call(self.session, 'callid', timestamp, queue_name, 27)
         res = self.session.query(StatCallOnQueue).filter(StatCallOnQueue.callid == 'callid')
 
-        self.assertEqual(res[0].callid, 'callid')
-        self.assertEqual(res[0].waittime, 27)
+        assert res[0].callid == 'callid'
+        assert res[0].waittime == 27
 
     def test_get_periodic_stats_full(self):
         start = dt(2012, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -125,9 +125,9 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         self.assertTrue(dt(2012, 1, 1, 1, tzinfo=UTC) in stats_quarter_hour)
         self.assertTrue(dt(2012, 1, 1, 2, tzinfo=UTC) in stats_quarter_hour)
 
-        self.assertEqual(stats_quarter_hour[start][queue_id]['full'], 1)
-        self.assertEqual(stats_quarter_hour[start + timedelta(minutes=15)][queue_id]['full'], 2)
-        self.assertEqual(stats_quarter_hour[start + timedelta(minutes=30)][queue_id]['full'], 1)
+        assert stats_quarter_hour[start][queue_id]['full'] == 1
+        assert stats_quarter_hour[start + timedelta(minutes=15)][queue_id]['full'] == 2
+        assert stats_quarter_hour[start + timedelta(minutes=30)][queue_id]['full'] == 1
 
         stats_hour = stat_call_on_queue_dao.get_periodic_stats_hour(self.session, start, end)
 
@@ -135,7 +135,7 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         self.assertTrue(dt(2012, 1, 1, 1, tzinfo=UTC) in stats_hour)
         self.assertTrue(dt(2012, 1, 1, 2, tzinfo=UTC) in stats_hour)
 
-        self.assertEqual(stats_hour[start][queue_id]['full'], 4)
+        assert stats_hour[start][queue_id]['full'] == 4
 
     def test_get_periodic_stats_closed(self):
         start = dt(2012, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -154,9 +154,9 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         self.assertTrue(dt(2012, 1, 1, 1, tzinfo=UTC) in stats_quarter_hour)
         self.assertTrue(dt(2012, 1, 1, 2, tzinfo=UTC) in stats_quarter_hour)
 
-        self.assertEqual(stats_quarter_hour[start][queue_id]['closed'], 1)
-        self.assertEqual(stats_quarter_hour[start + timedelta(minutes=15)][queue_id]['closed'], 2)
-        self.assertEqual(stats_quarter_hour[start + timedelta(minutes=30)][queue_id]['closed'], 1)
+        assert stats_quarter_hour[start][queue_id]['closed'] == 1
+        assert stats_quarter_hour[start + timedelta(minutes=15)][queue_id]['closed'] == 2
+        assert stats_quarter_hour[start + timedelta(minutes=30)][queue_id]['closed'] == 1
 
         stats_hour = stat_call_on_queue_dao.get_periodic_stats_hour(self.session, start, end)
 
@@ -164,7 +164,7 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         self.assertTrue(dt(2012, 1, 1, 1, tzinfo=UTC) in stats_hour)
         self.assertTrue(dt(2012, 1, 1, 2, tzinfo=UTC) in stats_hour)
 
-        self.assertEqual(stats_hour[start][queue_id]['closed'], 4)
+        assert stats_hour[start][queue_id]['closed'] == 4
 
     def test_get_periodic_stats_total(self):
         start = dt(2012, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -196,9 +196,9 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         self.assertTrue(dt(2012, 1, 1, 1, tzinfo=UTC) in stats_quarter_hour)
         self.assertTrue(dt(2012, 1, 1, 2, tzinfo=UTC) in stats_quarter_hour)
 
-        self.assertEqual(stats_quarter_hour[start][queue_id]['total'], 3)
-        self.assertEqual(stats_quarter_hour[start + timedelta(minutes=15)][queue_id]['total'], 4)
-        self.assertEqual(stats_quarter_hour[start + timedelta(minutes=30)][queue_id]['total'], 2)
+        assert stats_quarter_hour[start][queue_id]['total'] == 3
+        assert stats_quarter_hour[start + timedelta(minutes=15)][queue_id]['total'] == 4
+        assert stats_quarter_hour[start + timedelta(minutes=30)][queue_id]['total'] == 2
 
         stats_hour = stat_call_on_queue_dao.get_periodic_stats_hour(self.session, start, end)
 
@@ -206,7 +206,7 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         self.assertTrue(dt(2012, 1, 1, 1, tzinfo=UTC) in stats_hour)
         self.assertTrue(dt(2012, 1, 1, 2, tzinfo=UTC) in stats_hour)
 
-        self.assertEqual(stats_hour[start][queue_id]['total'], 9)
+        assert stats_hour[start][queue_id]['total'] == 9
 
     def test_clean_table(self):
         start = dt(2012, 1, 1, 0, 0, 0, tzinfo=UTC)
@@ -222,7 +222,7 @@ class TestStatCallOnQueueDAO(DAOTestCase):
 
         total = (self.session.query(func.count(StatCallOnQueue.callid))).first()[0]
 
-        self.assertEqual(total, 0)
+        assert total == 0
 
     def test_remove_after(self):
         stat_call_on_queue_dao.remove_after(self.session, dt(2012, 1, 1, tzinfo=UTC))
@@ -236,8 +236,8 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         stat_call_on_queue_dao.remove_after(self.session, dt(2012, 1, 2, tzinfo=UTC))
 
         callids = self.session.query(StatCallOnQueue.callid)
-        self.assertEqual(callids.count(), 1)
-        self.assertEqual(callids[0].callid, 'callid1')
+        assert callids.count() == 1
+        assert callids[0].callid == 'callid1'
 
     def test_find_all_callid_between_date(self):
         callid1 = 'callid1'
@@ -295,4 +295,4 @@ class TestStatCallOnQueueDAO(DAOTestCase):
         stat_call_on_queue_dao.remove_callids(self.session, [callid1, callid2, callid3])
 
         callids = self.session.query(StatCallOnQueue.callid)
-        self.assertEqual(callids.count(), 0)
+        assert callids.count() == 0

--- a/xivo_dao/tests/test_stat_dao.py
+++ b/xivo_dao/tests/test_stat_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -7,7 +7,7 @@ import pytz
 from datetime import datetime as t
 import pathlib
 
-from hamcrest import assert_that, contains, contains_inanyorder, equal_to, has_properties
+from hamcrest import assert_that, contains_exactly, contains_inanyorder, equal_to, has_properties
 
 from sqlalchemy import func
 
@@ -248,7 +248,7 @@ class TestFillSimpleCall(DAOTestCase):
         stat_dao.fill_simple_calls(self.session, start, end)
 
         result = self.session.query(StatCallOnQueue).all()
-        assert_that(result, contains(has_properties(status='full')))
+        assert_that(result, contains_exactly(has_properties(status='full')))
 
     def test_with_specific_timezone(self):
         # Asia/Shanghai is +08
@@ -258,7 +258,7 @@ class TestFillSimpleCall(DAOTestCase):
         stat_dao.fill_simple_calls(self.session, start, end)
 
         result = self.session.query(StatCallOnQueue).all()
-        assert_that(result, contains(has_properties(status='full')))
+        assert_that(result, contains_exactly(has_properties(status='full')))
 
     def _create_functions(self):
         # WARNING: This functions should always be the same as the one in xivo-manage-db
@@ -322,7 +322,7 @@ class TestFillLeaveEmptyCall(DAOTestCase):
         stat_dao.fill_leaveempty_calls(self.session, start, end)
 
         result = self.session.query(StatCallOnQueue).all()
-        assert_that(result, contains(has_properties(callid=self.callid_found)))
+        assert_that(result, contains_exactly(has_properties(callid=self.callid_found)))
 
     def test_with_specific_timezone(self):
         # Asia/Shanghai is +08
@@ -332,7 +332,7 @@ class TestFillLeaveEmptyCall(DAOTestCase):
         stat_dao.fill_leaveempty_calls(self.session, start, end)
 
         result = self.session.query(StatCallOnQueue).all()
-        assert_that(result, contains(has_properties(callid=self.callid_found)))
+        assert_that(result, contains_exactly(has_properties(callid=self.callid_found)))
 
     def _create_functions(self):
         # WARNING: This functions should always be the same as the one in xivo-manage-db

--- a/xivo_dao/tests/test_stat_dao.py
+++ b/xivo_dao/tests/test_stat_dao.py
@@ -358,7 +358,7 @@ class TestStatDAO(DAOTestCase):
     def test_get_login_intervals_in_range_calls_empty(self):
         result = stat_dao.get_login_intervals_in_range(self.session, self.start, self.end)
 
-        self.assertEqual(len(result), 0)
+        assert len(result) == 0
 
     def test_get_login_intervals_when_login_same_as_start_no_logoff(self):
         context = self.add_context()
@@ -382,7 +382,7 @@ class TestStatDAO(DAOTestCase):
             self.aid1: sorted([(logins[0]['time'], self.end)])
         }
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_get_login_intervals_when_logoff_same_as_start_no_login(self):
         context = self.add_context()
@@ -403,7 +403,7 @@ class TestStatDAO(DAOTestCase):
 
         result = stat_dao.get_login_intervals_in_range(self.session, self.start, self.end)
 
-        self.assertEqual(len(result), 0)
+        assert len(result) == 0
 
     def test_get_login_intervals_when_logoff_after_end_no_login(self):
         context = self.add_context()
@@ -428,7 +428,7 @@ class TestStatDAO(DAOTestCase):
 
         result = stat_dao.get_login_intervals_in_range(self.session, self.start, self.end)
 
-        self.assertEqual(len(result), 0)
+        assert len(result) == 0
 
     def test_get_login_intervals_when_login_after_range(self):
         context = self.add_context()
@@ -475,7 +475,7 @@ class TestStatDAO(DAOTestCase):
             self.aid1: sorted([(logintime, logouttime)])
         }
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_get_login_intervals_when_login_after_range_no_logoff(self):
         context = self.add_context()
@@ -500,7 +500,7 @@ class TestStatDAO(DAOTestCase):
 
         result = stat_dao.get_login_intervals_in_range(self.session, self.start, self.end)
 
-        self.assertEqual(len(result), 0)
+        assert len(result) == 0
 
     def test_get_login_intervals_when_logoff_same_as_end_no_login(self):
         context = self.add_context()
@@ -529,7 +529,7 @@ class TestStatDAO(DAOTestCase):
             self.aid1: sorted([(logintime, logouttime)])
         }
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_get_login_intervals_in_range_calls_logins_in_range(self):
         context = self.add_context()
@@ -588,7 +588,7 @@ class TestStatDAO(DAOTestCase):
                                (cb_logins[1]['time'], cb_logoffs[1]['time'])]),
         }
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_get_login_intervals_in_range_logins_before_no_logout(self):
         context = self.add_context()
@@ -619,7 +619,7 @@ class TestStatDAO(DAOTestCase):
             self.aid1: [(self.start, self.end)],
         }
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_get_login_intervals_in_range_no_login_logout_calls(self):
         connect1 = QueueLog(
@@ -650,7 +650,7 @@ class TestStatDAO(DAOTestCase):
 
         expected = {}
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def _insert_agent_callback_logins_logoffs(self, logins, logoffs):
         with flush_session(self.session):
@@ -878,7 +878,7 @@ class TestStatDAO(DAOTestCase):
                         (4, 5),
                         (5, 8)]}
 
-        self.assertEqual(len(statistics), len(expected))
+        assert len(statistics) == len(expected)
 
         for agent, statistic in statistics.items():
             for login in statistic:
@@ -892,16 +892,16 @@ class TestStatDAO(DAOTestCase):
         items = [(1, 2), (2, 3)]
         result = stat_dao._filter_overlap(items)
 
-        self.assertEqual(sorted(result), sorted(items))
+        assert sorted(result) == sorted(items)
 
         items = [(1, 2), (2, 3), (2, 4)]
         expected = [(1, 2), (2, 4)]
         result = stat_dao._filter_overlap(items)
 
-        self.assertEqual(sorted(result), sorted(expected))
+        assert sorted(result) == sorted(expected)
 
         items = [(1, 2), (2, 4), (3, 4)]
         expected = [(1, 2), (2, 4)]
         result = stat_dao._filter_overlap(items)
 
-        self.assertEqual(sorted(result), sorted(expected))
+        assert sorted(result) == sorted(expected)

--- a/xivo_dao/tests/test_stat_dao_extended.py
+++ b/xivo_dao/tests/test_stat_dao_extended.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -166,7 +166,7 @@ class TestStatDAO(DAOTestCase):
             ],
         }
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_get_last_logouts(self):
         _, agent_id_1 = self._insert_agent('Agent/1')
@@ -197,7 +197,7 @@ class TestStatDAO(DAOTestCase):
             agent_id_2: dt(2012, 6, 1, 6, 30, 0, 1, tzinfo=UTC),
         }
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_get_last_logins(self):
         _, agent_id_1 = self._insert_agent('Agent/1')
@@ -232,7 +232,7 @@ class TestStatDAO(DAOTestCase):
             agent_id_3: dt(2012, 1, 1, 10, tzinfo=UTC),
         }
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_get_ongoing_logins(self):
         _, agent_id_1 = self._insert_agent('Agent/1')
@@ -272,7 +272,7 @@ class TestStatDAO(DAOTestCase):
             ],
         }
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_get_pause_intervals_in_range(self):
         _, agent_id_1 = self._insert_agent('Agent/1')
@@ -306,7 +306,7 @@ class TestStatDAO(DAOTestCase):
             ]
         }
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_get_pause_intervals_in_range_multiple_pauseall(self):
         _, agent_id_1 = self._insert_agent('Agent/1')
@@ -341,7 +341,7 @@ class TestStatDAO(DAOTestCase):
             ]
         }
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def _insert_queue_log_data(self, queue_log_data):
         with flush_session(self.session):

--- a/xivo_dao/tests/test_stat_queue_dao.py
+++ b/xivo_dao/tests/test_stat_queue_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -18,7 +18,7 @@ class TestStatQueueDAO(DAOTestCase):
 
         result = stat_queue_dao.id_from_name(queue.name)
 
-        self.assertEqual(result, queue.id)
+        assert result == queue.id
 
     def test_insert_if_missing(self):
         # queue1: in confd + in cel + in stat

--- a/xivo_dao/tests/test_stat_queue_periodic_dao.py
+++ b/xivo_dao/tests/test_stat_queue_periodic_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime as dt
@@ -54,16 +54,16 @@ class TestStatQueuePeriodicDAO(DAOTestCase):
             result = (self.session.query(StatQueuePeriodic)
                       .filter(StatQueuePeriodic.time == period_start)[0])
 
-            self.assertEqual(result.abandoned, 7)
-            self.assertEqual(result.answered, 27)
-            self.assertEqual(result.closed, 5)
-            self.assertEqual(result.full, 4)
-            self.assertEqual(result.joinempty, 2)
-            self.assertEqual(result.leaveempty, 11)
-            self.assertEqual(result.timeout, 5)
-            self.assertEqual(result.divert_ca_ratio, 22)
-            self.assertEqual(result.divert_waittime, 15)
-            self.assertEqual(result.total, 98)
+            assert result.abandoned == 7
+            assert result.answered == 27
+            assert result.closed == 5
+            assert result.full == 4
+            assert result.joinempty == 2
+            assert result.leaveempty == 11
+            assert result.timeout == 5
+            assert result.divert_ca_ratio == 22
+            assert result.divert_waittime == 15
+            assert result.total == 98
         except LookupError:
             self.fail('Should have found a row')
 
@@ -82,7 +82,7 @@ class TestStatQueuePeriodicDAO(DAOTestCase):
         result = stat_queue_periodic_dao.get_most_recent_time(self.session)
         expected = start + timedelta(minutes=120)
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_clean_table(self):
         queue_name, queue_id = self._insert_queue_to_stat_queue()
@@ -100,7 +100,7 @@ class TestStatQueuePeriodicDAO(DAOTestCase):
 
         total = self.session.query(func.count(StatQueuePeriodic.time))[0][0]
 
-        self.assertEqual(total, 0)
+        assert total == 0
 
     def test_remove_after(self):
         queue_name, queue_id = self._insert_queue_to_stat_queue()
@@ -120,5 +120,5 @@ class TestStatQueuePeriodicDAO(DAOTestCase):
 
         res = self.session.query(StatQueuePeriodic.time)
 
-        self.assertEqual(res.count(), 1)
-        self.assertEqual(res[0].time, dt(2012, 1, 1, tzinfo=UTC))
+        assert res.count() == 1
+        assert res[0].time == dt(2012, 1, 1, tzinfo=UTC)


### PR DESCRIPTION
## tests: replace contains with contains_exactly

Why:

* remove pytest warnings

## tests: replace assertEqual with assert

Why:

* better output with pytest
* remove warnings in pytest

## tests: remove warning about duplicate view name


## stat dao: remove sqlalchemy warning