### PR TITLE
schedule: add relationship for destinations

### DIFF
--- a/xivo_dao/alchemy/schedule.py
+++ b/xivo_dao/alchemy/schedule.py
@@ -97,6 +97,88 @@ class Schedule(Base):
     )
     queues = association_proxy('schedule_queues', 'queue')
 
+    # Begin definitions for fallback destination
+    conference = relationship(
+        'Conference',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'conference',
+            Schedule.fallback_actionid == cast(Conference.id, String)
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+
+    group = relationship(
+        'GroupFeatures',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'group',
+            Schedule.fallback_actionid == cast(GroupFeatures.id, String)
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+
+    user = relationship(
+        'UserFeatures',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'user',
+            Schedule.fallback_actionid == cast(UserFeatures.id, String)
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+
+    ivr = relationship(
+        'IVR',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'ivr',
+            Schedule.fallback_actionid == cast(IVR.id, String)
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+
+    switchboard = relationship(
+        'Switchboard',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'switchboard',
+            Schedule.fallback_actionid == Switchboard.uuid
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+
+    voicemail = relationship(
+        'Voicemail',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'voicemail',
+            Schedule.fallback_actionid == cast(Voicemail.id, String)
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+
+    application = relationship(
+        'Application',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'application:custom',
+            Schedule.fallback_actionid == Application.uuid
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+
+    queue = relationship(
+        'QueueFeatures',
+        primaryjoin="""and_(
+            Schedule.fallback_action == 'queue',
+            Schedule.fallback_actionid == cast(QueueFeatures.id, String)
+        )""",
+        foreign_keys='Schedule.fallback_actionid',
+        viewonly=True,
+    )
+    # End definitions for fallback destination
+
     @property
     def open_periods(self):
         return self._get_periods('opened')

--- a/xivo_dao/alchemy/schedule_time.py
+++ b/xivo_dao/alchemy/schedule_time.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Column, PrimaryKeyConstraint, Index
 from sqlalchemy.types import Integer, String, Enum
 
@@ -32,6 +33,86 @@ class ScheduleTime(Base):
     actionid = Column(IntAsString(255))
     actionargs = Column(String(255))
     commented = Column(Integer, nullable=False, server_default='0')
+
+    conference = relationship(
+        'Conference',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'conference',
+            ScheduleTime.actionid == cast(Conference.id, String)
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
+
+    group = relationship(
+        'GroupFeatures',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'group',
+            ScheduleTime.actionid == cast(GroupFeatures.id, String)
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
+
+    user = relationship(
+        'UserFeatures',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'user',
+            ScheduleTime.actionid == cast(UserFeatures.id, String)
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
+
+    ivr = relationship(
+        'IVR',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'ivr',
+            ScheduleTime.actionid == cast(IVR.id, String)
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
+
+    switchboard = relationship(
+        'Switchboard',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'switchboard',
+            ScheduleTime.actionid == Switchboard.uuid
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
+
+    voicemail = relationship(
+        'Voicemail',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'voicemail',
+            ScheduleTime.actionid == cast(Voicemail.id, String)
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
+
+    application = relationship(
+        'Application',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'application:custom',
+            ScheduleTime.actionid == Application.uuid
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
+
+    queue = relationship(
+        'QueueFeatures',
+        primaryjoin="""and_(
+            ScheduleTime.action == 'queue',
+            ScheduleTime.actionid == cast(QueueFeatures.id, String)
+        )""",
+        foreign_keys='ScheduleTime.actionid',
+        viewonly=True,
+    )
 
     @property
     def destination(self):


### PR DESCRIPTION
why: allow to return readonly attibute (eg: name) in the API