### PR TITLE
parking_lot: improve validation for in_slots_range

### DIFF
--- a/xivo_dao/alchemy/parking_lot.py
+++ b/xivo_dao/alchemy/parking_lot.py
@@ -54,6 +54,9 @@ class ParkingLot(Base):
     )
 
     def in_slots_range(self, exten):
+        if not str(exten).isdigit() or str(exten).startswith('0'):
+            return False
+
         exten = int(exten)
         start = int(self.slots_start)
         end = int(self.slots_end)

--- a/xivo_dao/alchemy/tests/test_parking_lot.py
+++ b/xivo_dao/alchemy/tests/test_parking_lot.py
@@ -25,6 +25,18 @@ class TestInSlotsRange(unittest.TestCase):
         result = self.parking_lot.in_slots_range('725')
         assert_that(result, equal_to(True))
 
+    def test_in_range_str_pattern(self):
+        result = self.parking_lot.in_slots_range('_725')
+        assert_that(result, equal_to(False))
+
+    def test_in_range_str_char(self):
+        result = self.parking_lot.in_slots_range('*725')
+        assert_that(result, equal_to(False))
+
+    def test_in_range_str_beginning_zero(self):
+        result = self.parking_lot.in_slots_range('0725')
+        assert_that(result, equal_to(False))
+
     def test_limit_start_range(self):
         result = self.parking_lot.in_slots_range(701)
         assert_that(result, equal_to(True))


### PR DESCRIPTION
why: exten is a string and something cannot be cast to int