### PR TITLE
use docker compose without hyphen command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ database by passing `CREATE_TABLES=0` on the command line
 Start the database (needed only once):
 
 ```sh
-docker-compose up -d db
-export XIVO_TEST_DB_URL=postgresql://asterisk:proformatique@$(docker-compose port db 5432)/asterisk
+docker compose up -d db
+export XIVO_TEST_DB_URL=postgresql://asterisk:proformatique@$(docker compose port db 5432)/asterisk
 ```
 
 Run your tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   db:
     image: postgres

--- a/zuul.d/roles/xivo-dao-db/tasks/main.yml
+++ b/zuul.d/roles/xivo-dao-db/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Start DB container
-  command: docker-compose up -d
+  command: docker compose up -d
   args:
     chdir: "{{ zuul.project.src_dir }}"
 - name: Get DB container port
-  command: docker-compose port db 5432
+  command: docker compose port db 5432
   register: container_port
   args:
     chdir: "{{ zuul.project.src_dir }}"


### PR DESCRIPTION
why: it's now the recommended way to use docker compose