### PR TITLE
phone numbers find by number in

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,7 @@ repos:
     rev: 23.10.1
     hooks:
       - id: black
+  - repo: https://github.com/wazo-platform/wazo-git-hooks.git
+    rev: 1.1.3
+    hooks:
+    - id: wazo-copyright-check

--- a/xivo_dao/helpers/sequence_utils.py
+++ b/xivo_dao/helpers/sequence_utils.py
@@ -1,0 +1,21 @@
+# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from collections.abc import Callable, Iterable
+from typing import TypeVar
+
+T = TypeVar('T')
+
+Predicate = Callable[[T], bool]
+
+
+def split_by(seq: Iterable[T], pred: Predicate[T]) -> tuple[list[T], list[T]]:
+    approved = []
+    rejected = []
+    for x in seq:
+        if pred(x):
+            approved.append(x)
+        else:
+            rejected.append(x)
+
+    return approved, rejected

--- a/xivo_dao/helpers/tests/test_sequence_utils.py
+++ b/xivo_dao/helpers/tests/test_sequence_utils.py
@@ -1,0 +1,36 @@
+# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from xivo_dao.helpers.sequence_utils import split_by
+
+
+class TestSplitBy(unittest.TestCase):
+    def test_split_by(self):
+        seq = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        approved, rejected = split_by(seq, lambda x: x < 5)
+        self.assertEqual(approved, [0, 1, 2, 3, 4])
+        self.assertEqual(rejected, [5, 6, 7, 8, 9])
+
+    def test_split_by_empty(self):
+        seq = []
+        approved, rejected = split_by(seq, lambda x: x < 5)
+        self.assertEqual(approved, [])
+        self.assertEqual(rejected, [])
+
+    def test_split_by_all_rejected(self):
+        seq = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        approved, rejected = split_by(seq, lambda x: x > 10)
+        self.assertEqual(approved, [])
+        self.assertEqual(rejected, seq)
+
+    def test_split_by_all_approved(self):
+        seq = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        approved, rejected = split_by(seq, lambda x: x < 10)
+        self.assertEqual(approved, seq)
+        self.assertEqual(rejected, [])
+
+    def test_split_by_non_iterable(self):
+        seq = None
+        with self.assertRaises(TypeError):
+            _ = split_by(seq, lambda x: x)

--- a/xivo_dao/resources/phone_number/persistor.py
+++ b/xivo_dao/resources/phone_number/persistor.py
@@ -4,6 +4,7 @@
 from xivo_dao.alchemy.phone_number import PhoneNumber
 
 from xivo_dao.helpers.persistor import BasePersistor
+from xivo_dao.helpers.sequence_utils import split_by
 from xivo_dao.resources.utils.search import CriteriaBuilderMixin
 
 
@@ -15,11 +16,24 @@ class Persistor(CriteriaBuilderMixin, BasePersistor):
         self.search_system = search_system
         self.tenant_uuids = tenant_uuids
 
+    def build_bulk_criteria(self, query, criteria):
+        for key, value in criteria.items():
+            assert key.endswith('_in')
+            column_name = key[:-3]
+            column = self._get_column(column_name)
+            query = query.filter(column.in_(value))
+        return query
+
     def _find_query(self, criteria):
         query = self.session.query(PhoneNumber)
         if self.tenant_uuids is not None:
             query = query.filter(PhoneNumber.tenant_uuid.in_(self.tenant_uuids))
-        return self.build_criteria(query, criteria)
+        bulk_criteria, criteria = split_by(
+            criteria.items(), lambda x: x[0].endswith('_in')
+        )
+        query = self.build_bulk_criteria(query, dict(bulk_criteria))
+        query = self.build_criteria(query, dict(criteria))
+        return query
 
     def _search_query(self):
         return self.session.query(PhoneNumber)

--- a/xivo_dao/resources/phone_number/tests/test_dao.py
+++ b/xivo_dao/resources/phone_number/tests/test_dao.py
@@ -281,6 +281,14 @@ class TestFindAllBy(DAOTestCase):
 
         assert_that(result, contains_exactly(row))
 
+    def test_find_all_by_multiple_numbers(self):
+        row1 = self.add_phone_number(number=SAMPLE_NUMBER)
+        row2 = self.add_phone_number(number=SAMPLE_NUMBER_2)
+
+        result = dao.find_all_by(number_in=[SAMPLE_NUMBER, SAMPLE_NUMBER_2])
+
+        assert_that(result, contains_exactly(row1, row2))
+
 
 class TestSearch(DAOTestCase):
     def assert_search_returns_result(self, search_result, **parameters):


### PR DESCRIPTION
- **helpers: split_by utility function to split a sequence in two according to a predicate**
- **Added wazo-copyright-check hook in pre-commit config**
- **resources.phone_number: added bulk criteria support for find queries**
