### PR TITLE
[WAZO-3666] Use usersharedlines for queue

### DIFF
--- a/xivo_dao/asterisk_conf_dao.py
+++ b/xivo_dao/asterisk_conf_dao.py
@@ -1183,12 +1183,12 @@ def find_queue_members_settings(session, queue_name):
         .all()
     )
 
-    def is_user_in_group(row):
-        return row.category == 'group' and row.uuid is not None
+    def is_user(row):
+        return row.uuid is not None
 
     res = []
     for row in user_members:
-        if is_user_in_group(row):
+        if is_user(row):
             member = Member(
                 interface=f'Local/{row.uuid}@usersharedlines',
                 penalty=str(row.penalty),

--- a/xivo_dao/tests/test_asterisk_conf_dao.py
+++ b/xivo_dao/tests/test_asterisk_conf_dao.py
@@ -986,6 +986,16 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
             commented=1,
         )
 
+        user_queue = self.add_user()
+        self.add_queue_member(
+            queue_name=queue_name,
+            interface='ignored',
+            usertype='user',
+            userid=user_queue.id,
+            penalty=0,
+            commented=0,
+        )
+
         result = asterisk_conf_dao.find_queue_members_settings(queue_name)
         assert_that(
             result,
@@ -993,6 +1003,12 @@ class TestAsteriskConfDAO(DAOTestCase, PickupHelperMixin):
                 contains_exactly('Local/100@default', '1', '', ''),
                 contains_exactly('PJSIP/3m6dsc', '5', '', ''),
                 contains_exactly('SCCP/1003', '15', '', ''),
+                contains_exactly(
+                    f'Local/{user_queue.uuid}@usersharedlines',
+                    '0',
+                    '',
+                    f'hint:{user_queue.uuid}@usersharedlines',
+                ),
             ),
         )
 


### PR DESCRIPTION
Why: we want both queue and group members to be using usersharedlines, not only
group.
