### PR TITLE
cleanup: remove incalls obsolete code

### DIFF
--- a/xivo_dao/alchemy/incall.py
+++ b/xivo_dao/alchemy/incall.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -15,7 +15,6 @@ from sqlalchemy.sql import (
     select,
 )
 from sqlalchemy.types import (
-    Boolean,
     Integer,
     String,
     Text,
@@ -41,9 +40,6 @@ class Incall(Base):
         ForeignKey('tenant.uuid', ondelete='CASCADE'),
         nullable=False,
     )
-
-    # NOTE(WAZO-3715): This field is a workaround and must not be exposed to the API.
-    main = Column(Boolean, nullable=False, server_default='false')
 
     preprocess_subroutine = Column(String(79))
     greeting_sound = Column(Text)

--- a/xivo_dao/resources/incall/dao.py
+++ b/xivo_dao/resources/incall/dao.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from contextlib import contextmanager
@@ -35,10 +35,6 @@ def find_by(tenant_uuids=None, **criteria):
 
 def find_all_by(tenant_uuids=None, **criteria):
     return persistor(tenant_uuids).find_all_by(criteria)
-
-
-def find_main_callerid(tenant_uuid):
-    return persistor().find_main_callerid(tenant_uuid)
 
 
 def create(incall):

--- a/xivo_dao/resources/incall/persistor.py
+++ b/xivo_dao/resources/incall/persistor.py
@@ -1,9 +1,5 @@
-# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
-from sqlalchemy.sql import cast
-from sqlalchemy.sql.expression import and_, literal_column
-from sqlalchemy.types import String
 
 from xivo_dao.alchemy.extension import Extension
 from xivo_dao.alchemy.incall import Incall
@@ -22,18 +18,9 @@ class IncallPersistor(QueryOptionsMixin, CriteriaBuilderMixin, BasePersistor):
         self.tenant_uuids = tenant_uuids
 
     def create(self, incall):
-        incall.main = not self._is_main_already_exists(incall.tenant_uuid)
         self.session.add(incall)
         self.session.flush()
         return incall
-
-    def _is_main_already_exists(self, tenant_uuid):
-        return (
-            self.session.query(Incall)
-            .filter(Incall.main.is_(True))
-            .filter(Incall.tenant_uuid == tenant_uuid)
-            .first()
-        )
 
     def _find_query(self, criteria):
         query = self._generate_query()
@@ -55,24 +42,3 @@ class IncallPersistor(QueryOptionsMixin, CriteriaBuilderMixin, BasePersistor):
             .filter(Extension.typeval == str(incall.id))
             .update({'type': 'user', 'typeval': '0'})
         )
-
-    def find_main_callerid(self, tenant_uuid):
-        query = (
-            self.session.query(
-                Extension.exten.label('number'),
-                literal_column("'main'").label('type'),
-            )
-            .select_from(Incall)
-            .join(
-                Extension,
-                and_(
-                    Extension.type == 'incall',
-                    Extension.typeval == cast(Incall.id, String),
-                ),
-            )
-            .filter(
-                Incall.tenant_uuid == tenant_uuid,
-                Incall.main.is_(True),
-            )
-        )
-        return query.first()


### PR DESCRIPTION
why: remove deprecated temporary solution for dynamic caller id
superceded by 'phone_number' data model & separate APIs