### PR TITLE
WAZO-3870: Handle non-latin characters in search

### DIFF
--- a/xivo_dao/resources/utils/search.py
+++ b/xivo_dao/resources/utils/search.py
@@ -13,8 +13,13 @@ import sqlalchemy as sa
 from sqlalchemy import sql
 from sqlalchemy.sql.functions import ReturnTypeFromArgs
 from sqlalchemy.types import Integer
+import re
 
 from xivo_dao.helpers import errors
+
+
+def contains_latin(text):
+    return bool(re.search(r'[a-zA-Z]', text))  # Check if the text has Latin characters
 
 
 class SearchResult(NamedTuple):
@@ -138,7 +143,7 @@ class SearchSystem:
 
         criteria = []
         for column in self.config.all_search_columns():
-            clean_term = unidecode(term)
+            clean_term = unidecode(term) if contains_latin(term) else term
             expression = unaccent(sql.cast(column, sa.String)).ilike(f'%{clean_term}%')
             criteria.append(expression)
 


### PR DESCRIPTION
Searching with non-latin characters doesn't work because of `unidecode`. 
With this PR, it will only use `unidecode` only if there is a latin character in the search term (To remove accents). Otherwise it will use the original search term.