### PR TITLE
execute refresh materialized view on commit only

### DIFF
--- a/xivo_dao/alchemy/tests/test_endpoint_sip.py
+++ b/xivo_dao/alchemy/tests/test_endpoint_sip.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from hamcrest import (
@@ -398,6 +398,7 @@ class TestCallerId(DAOTestCase):
         sip = self.add_endpoint_sip(
             templates=[template1, template2], caller_id='template3'
         )
+        EndpointSIPOptionsView.refresh()  # Simulate a database commit
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template3'))
@@ -406,6 +407,7 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(caller_id='template1')
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
+        EndpointSIPOptionsView.refresh()  # Simulate a database commit
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template1'))
@@ -415,6 +417,7 @@ class TestCallerId(DAOTestCase):
         template1 = self.add_endpoint_sip(templates=[template0])
         template2 = self.add_endpoint_sip(caller_id='template2')
         sip = self.add_endpoint_sip(templates=[template1, template2])
+        EndpointSIPOptionsView.refresh()  # Simulate a database commit
 
         result = sip.get_option_value('callerid')
         assert_that(result, equal_to('template0'))
@@ -422,6 +425,7 @@ class TestCallerId(DAOTestCase):
     def test_callerid_inheritance(self):
         template1 = self.add_endpoint_sip(caller_id='template1')
         sip = self.add_endpoint_sip(templates=[template1])
+        EndpointSIPOptionsView.refresh()  # Simulate a database commit
 
         assert_that(sip.get_option_value('callerid'), equal_to('template1'))
         assert_that(template1.get_option_value('callerid'), equal_to('template1'))

--- a/xivo_dao/helpers/db_views.py
+++ b/xivo_dao/helpers/db_views.py
@@ -1,11 +1,11 @@
-# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from collections.abc import Callable
 
-from sqlalchemy import Table, text
+from sqlalchemy import Table
 from sqlalchemy.event import listens_for, contains
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm.unitofwork import UOWTransaction
@@ -35,26 +35,28 @@ class MaterializedView(Base):
                 f"Class '{cls}' '__table__' attribute must be created with 'create_materialized_view'"
             )
         super().__init_subclass__()
+        _custom_dirty_attr = f'_wazo_{cls.__table__}_has_been_flushed_being_dirty'
 
         if targets := cls.__view_dependencies__:
 
             @listens_for(Session, 'after_flush')
-            def _before_session_commit_handler(
+            def _after_session_flush_handler(
                 session: Session, flush_context: UOWTransaction
             ) -> None:
                 for obj in session.dirty | session.new | session.deleted:
                     if isinstance(obj, targets):
-                        # Cannot call `refresh_materialized_view` as it will try to flush again.
-                        session.execute(
-                            text(
-                                f'REFRESH MATERIALIZED VIEW CONCURRENTLY {cls.__table__.fullname}'
-                            )
-                        )
+                        setattr(session, _custom_dirty_attr, True)
                         return
 
-            cls._view_dependencies_handler = staticmethod(
-                _before_session_commit_handler
-            )
+            @listens_for(Session, 'before_commit')
+            def _before_session_commit_handler(session: Session) -> None:
+                session_was_dirty = getattr(session, _custom_dirty_attr, False)
+                if session_was_dirty:
+                    cls.refresh(concurrently=True)
+                    setattr(session, _custom_dirty_attr, False)
+                    return
+
+            cls._view_dependencies_handler = staticmethod(_after_session_flush_handler)
         else:
             cls._view_dependencies_handler = None
 

--- a/xivo_dao/resources/endpoint_sip/tests/test_dao.py
+++ b/xivo_dao/resources/endpoint_sip/tests/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -416,7 +416,9 @@ class TestCreate(DAOTestCase):
             ],
         )
 
-        result = sip_dao.create(model)  # create triggers view refresh
+        result = sip_dao.create(model)
+        self.session.commit()
+        self.session.expire(result)
 
         assert_that(result.get_option_value('some_key'), equal_to('some_value'))
         assert_that(result.get_option_value('other_key'), equal_to('other_value'))
@@ -507,6 +509,8 @@ class TestEdit(DAOTestCase):
             setattr(sip, field, options)
 
             sip_dao.edit(sip)
+            self.session.commit()
+            self.session.expire(sip)
 
             assert_that(sip.get_option_value('new-key'), equal_to(options[0][1]))
 
@@ -539,6 +543,7 @@ class TestDelete(DAOTestCase):
         assert_that(sip.get_option_value('some-key'), equal_to('some-value'))
 
         sip_dao.delete(parent)
+        self.session.commit()
         self.session.expire(sip)
 
         assert_that(inspect(parent).deleted)


### PR DESCRIPTION
why: users import will flush many time at each new user and refreshing
materialized view each time will slowdown (many minutes) the import