### PR TITLE
blocklist: BlocklistNumber.tenant_uuid

### DIFF
--- a/xivo_dao/alchemy/blocklist.py
+++ b/xivo_dao/alchemy/blocklist.py
@@ -68,6 +68,11 @@ class BlocklistNumber(Base):
         nullable=False,
     )
 
+    tenant_uuid = association_proxy(
+        'blocklist',
+        'tenant_uuid',
+    )
+
     blocklist = relationship(Blocklist, lazy='joined', uselist=False)
 
     @hybrid_property


### PR DESCRIPTION
association_proxy
why: filtering numbers based on tenant
